### PR TITLE
Fix a few small docker issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM gradle:8.13.0-jdk21 AS builder
+FROM gradle:8.9-jdk21 AS builder
 
 WORKDIR /app
-
 COPY . /app
 
+# Build the jar
 RUN gradle jar
 
 # Final, minimal image
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21
 
 WORKDIR /app
-
 COPY --from=builder /app/core/build/libs/hyperscale.jar /jar/hyperscale.jar
 
 CMD ["java", "-jar", "/jar/hyperscale.jar", "-console"]

--- a/compose.yml
+++ b/compose.yml
@@ -11,9 +11,12 @@ services:
       - "8080:8080"
       # Gossip port
       - "30000:30000"
+
     # Override the command if you need to, for example to run singleton mode
     # command: ["java", "-jar", "/jar/hyperscale.jar", "-console", "-singleton"]
+
     # Satisfy the send/receive buffer size requirements
-    sysctls:
-      net.core.rmem_max: 1048576
-      net.core.wmem_max: 1048576
+    # This may not work on all systems due to privilege restrictions
+    # sysctls:
+    #   net.core.rmem_max: 1048576
+    #   net.core.wmem_max: 1048576


### PR DESCRIPTION
@fpieper reported that increasing the send/rcv buffers in the docker compose config was causing an error for him, so I commented it out for now, making it up to the user (it does work for me).

I also changed the gradle version in the docker build to match the project's gradle version, which should be 8.9.
It seems that the 'openjdk' docker images are [deprecated](https://hub.docker.com/_/openjdk), so I changed it to use [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)