### PR TITLE
Bls optimization migration

### DIFF
--- a/core/src/main/java/org/miracl/core/BLS12381/DBIG.java
+++ b/core/src/main/java/org/miracl/core/BLS12381/DBIG.java
@@ -37,10 +37,15 @@ public class DBIG {
 	}
 
 
-/* split DBIG at position n, return higher half, keep lower half */
+	/* split DBIG at position n, return higher half, keep lower half */
 	public BIG split(int n)
 	{
-		BIG t=new BIG(0);
+		return split(n, new BIG(0));
+	}
+	
+/* split DBIG at position n, return higher half, keep lower half */
+	public BIG split(int n, BIG t)
+	{
 		int m=n%CONFIG_BIG.BASEBITS;
 		long nw,carry=w[BIG.DNLEN-1]<<(CONFIG_BIG.BASEBITS-m);
 
@@ -147,6 +152,12 @@ public class DBIG {
 		w[BIG.NLEN]=(x.w[(BIG.NLEN-1)]>>CONFIG_BIG.BASEBITS);
 
 		for (int i=BIG.NLEN+1;i<BIG.DNLEN;i++) w[i]=0;
+	}
+	
+	public void zero()
+	{
+		for (int i=0;i<BIG.DNLEN;i++)
+			w[i]=0;
 	}
 
 /* Copy from another DBIG */

--- a/core/src/main/java/org/miracl/core/BLS12381/FP12.java
+++ b/core/src/main/java/org/miracl/core/BLS12381/FP12.java
@@ -22,7 +22,21 @@
 
 package org.miracl.core.BLS12381;
 
-public final class FP12 {
+public final class FP12 
+{
+	// Working Variables //
+	private static final ThreadLocal<FP2[]> frobFP2_2 = ThreadLocal.withInitial(() -> new FP2[] {new FP2(), new FP2()});
+	private static final ThreadLocal<FP4[]> inverseFP4_4 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4(), new FP4(), new FP4()});
+	private static final ThreadLocal<FP4[]> mulFP4_4 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4(), new FP4(), new FP4()});
+	private static final ThreadLocal<FP4[]> mulFP4_2 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4()});
+	private static final ThreadLocal<BIG[]> powBIG_2 = ThreadLocal.withInitial(() -> new BIG[] {new BIG(), new BIG()});
+	private static final ThreadLocal<FP12[]> powFP12_2 = ThreadLocal.withInitial(() -> new FP12[] {new FP12(), new FP12()});
+	private static final ThreadLocal<FP4[]> sqrFP4_4 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4(), new FP4(), new FP4()});
+	private static final ThreadLocal<FP2[]> smulFP2_9 = ThreadLocal.withInitial(() -> new FP2[] {new FP2(), new FP2(), new FP2(), new FP2(), new FP2(), new FP2(), new FP2(), new FP2(), new FP2()});
+	private static final ThreadLocal<FP4[]> ssmulFP4_4 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4(), new FP4(), new FP4()});
+	private static final ThreadLocal<FP4[]> ssmulFP4_2 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4()});
+	private static final ThreadLocal<FP4[]> usqrFP4_4 = ThreadLocal.withInitial(() -> new FP4[] {new FP4(), new FP4(), new FP4(), new FP4()});
+
 	public static final int ZERO=0;
 	public static final int ONE=1;
 	public static final int SPARSEST=2;
@@ -106,10 +120,11 @@ public final class FP12 {
 
 
 /* test x==1 ? */
-	public boolean isunity() {
-		FP4 one=new FP4(1);
-		return (a.equals(one) && b.iszilch() && c.iszilch());
+	public boolean isunity() 
+	{
+		return (a.equals(FP4.ONE) && b.iszilch() && c.iszilch());
 	}
+	
 /* return 1 if x==y, else 0 */
 	public boolean equals(FP12 x)
 	{
@@ -130,6 +145,16 @@ public final class FP12 {
 	{
 		return c;
 	}
+	
+	public void copy(FP4 x, FP4 y, FP4 z, int t)
+	{
+		a.copy(x);
+		b.copy(y);
+		c.copy(z);
+		type=t;
+	}
+
+	
 /* copy this=x */
 	public void copy(FP12 x)
 	{
@@ -208,10 +233,11 @@ public final class FP12 {
 /* Granger-Scott Unitary Squaring */
 	public void usqr()
 	{
-		FP4 A=new FP4(a);
-		FP4 B=new FP4(c);
-		FP4 C=new FP4(b);
-		FP4 D=new FP4();
+		FP4[] FP4_4 = usqrFP4_4.get();
+		FP4 A=FP4_4[0]; A.copy(a);
+		FP4 B=FP4_4[1]; B.copy(c);
+		FP4 C=FP4_4[2]; C.copy(b);
+		FP4 D=FP4_4[3];
 
 		a.sqr();
 		D.copy(a); D.add(a);
@@ -251,10 +277,11 @@ public final class FP12 {
 		if (type==ONE)
 			return;
 
-		FP4 A=new FP4(a);
-		FP4 B=new FP4(b);
-		FP4 C=new FP4(c);
-		FP4 D=new FP4(a);
+		FP4[] FP4_4 = sqrFP4_4.get();
+		FP4 A=FP4_4[0]; A.copy(a);
+		FP4 B=FP4_4[1]; B.copy(b);
+		FP4 C=FP4_4[2]; C.copy(c);
+		FP4 D=FP4_4[3]; D.copy(a);
 
 		A.sqr();
 		B.mul(c);
@@ -295,12 +322,14 @@ public final class FP12 {
 /* FP12 full multiplication this=this*y */
 	public void mul(FP12 y)
 	{
-		FP4 z0=new FP4(a);
-		FP4 z1=new FP4();
-		FP4 z2=new FP4(b);
-		FP4 z3=new FP4();
-		FP4 t0=new FP4(a);
-		FP4 t1=new FP4(y.a);
+		FP4[] FP4_4 = mulFP4_4.get();
+		FP4[] FP4_2 = mulFP4_2.get();
+		FP4 z0=FP4_4[0]; z0.copy(a);
+		FP4 z1=FP4_4[1]; z1.zero();
+		FP4 z2=FP4_4[2]; z2.copy(b);
+		FP4 z3=FP4_4[3]; z3.zero();
+		FP4 t0=FP4_2[0]; t0.copy(a);
+		FP4 t1=FP4_2[1]; t1.copy(y.a);
 
 		z0.mul(y.a);
 		z2.mul(y.b);
@@ -358,6 +387,7 @@ public final class FP12 {
 /* w and y are both sparser or sparsest line functions - cost <= 6m */ 
 	public void smul(FP12 y)
 	{
+		FP2[] FP2_9 = smulFP2_9.get();
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.D_TYPE)
 		{	
 			FP2 w1=new FP2(a.geta());
@@ -429,8 +459,8 @@ public final class FP12 {
 			b.norm();
 
 		} else {
-			FP2 w1=new FP2(a.geta());
-			FP2 w2=new FP2(a.getb());
+			FP2 w1=FP2_9[0];w1.copy(a.geta());
+			FP2 w2=FP2_9[1];w2.copy(a.getb());
 			FP2 w3;
 
 			w1.mul(y.a.geta());
@@ -442,36 +472,36 @@ public final class FP12 {
 				{
 					FP t=new FP(c.getb().geta());
 					t.mul(y.c.getb().geta());
-					w3=new FP2(t);
+					w3=FP2_9[2]; w3.copy(t);
 				} else {
 					if (y.type!=SPARSEST)
 					{
-						w3=new FP2(y.c.getb());
+						w3=FP2_9[2]; w3.copy(y.c.getb());
 						w3.pmul(c.getb().geta());
 					} else {
-						w3=new FP2(c.getb());
+						w3=FP2_9[2]; w3.copy(c.getb());
 						w3.pmul(y.c.getb().geta());
 					}
 				}
 			} else {
-				w3=new FP2(c.getb());
+				w3=FP2_9[2]; w3.copy(c.getb());
 				w3.mul(y.c.getb());
 			}
 
-			FP2 ta=new FP2(a.geta());
-			FP2 tb=new FP2(y.a.geta());
+			FP2 ta=FP2_9[3]; ta.copy(a.geta());
+			FP2 tb=FP2_9[4]; tb.copy(y.a.geta());
 			ta.add(a.getb()); ta.norm();
 			tb.add(y.a.getb()); tb.norm();
-			FP2 tc=new FP2(ta);
+			FP2 tc=FP2_9[5]; tc.copy(ta);
 			tc.mul(tb);
-			FP2 t=new FP2(w1);
+			FP2 t=FP2_9[6]; t.copy(w1);
 			t.add(w2);
 			t.neg();
 			tc.add(t);
 
 			ta.copy(a.geta()); ta.add(c.getb()); ta.norm();
 			tb.copy(y.a.geta()); tb.add(y.c.getb()); tb.norm();
-			FP2 td=new FP2(ta);
+			FP2 td=FP2_9[7]; td.copy(ta);
 			td.mul(tb);
 			t.copy(w1);
 			t.add(w3);
@@ -480,7 +510,7 @@ public final class FP12 {
 
 			ta.copy(a.getb()); ta.add(c.getb()); ta.norm();
 			tb.copy(y.a.getb()); tb.add(y.c.getb()); tb.norm();
-			FP2 te=new FP2(ta);
+			FP2 te=FP2_9[8]; te.copy(ta);
 			te.mul(tb);
 			t.copy(w2);
 			t.add(w3);
@@ -522,10 +552,11 @@ public final class FP12 {
 
 		if (y.type>=SPARSE)
 		{
-			FP4 z0=new FP4(a);
-			FP4 z1=new FP4();
-			FP4 z2=new FP4();
-			FP4 z3=new FP4();
+			FP4 FP4_4[] = ssmulFP4_4.get();
+			FP4 z0=FP4_4[0]; z0.copy(a);
+			FP4 z1=FP4_4[1];
+			FP4 z2=FP4_4[2];
+			FP4 z3=FP4_4[3];
 			z0.mul(y.a);
 
 			if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.M_TYPE)
@@ -554,8 +585,9 @@ public final class FP12 {
 				z2.copy(b);
 				z2.mul(y.b);
 			}
-			FP4 t0=new FP4(a);
-			FP4 t1=new FP4(y.a);
+			FP4 FP4_2[] = ssmulFP4_2.get();
+			FP4 t0=FP4_2[0]; t0.copy(a);
+			FP4 t1=FP4_2[1]; t1.copy(y.a);
 			t0.add(b); t0.norm();
 			t1.add(y.b); t1.norm();
 
@@ -667,12 +699,14 @@ public final class FP12 {
 			}
 			if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.M_TYPE)
 			{
-				FP4 z0=new FP4(a);
-				FP4 z1=new FP4();
-				FP4 z2=new FP4();
-				FP4 z3=new FP4();
-				FP4 t0=new FP4(a);
-				FP4 t1=new FP4();
+				FP4 FP4_4[] = ssmulFP4_4.get();
+				FP4 FP4_2[] = ssmulFP4_2.get();
+				FP4 z0=FP4_4[0]; z0.copy(a);
+				FP4 z1=FP4_4[1];
+				FP4 z2=FP4_4[2];
+				FP4 z3=FP4_4[3];
+				FP4 t0=FP4_2[0]; t0.copy(a);
+				FP4 t1=FP4_2[1];
 		
 				z0.mul(y.a);
 				t0.add(b); t0.norm();
@@ -726,11 +760,12 @@ public final class FP12 {
 /* this=1/this */
 	public void inverse()
 	{
-		FP4 f0=new FP4(a);
-		FP4 f1=new FP4(b);
-		FP4 f2=new FP4(a);
-		FP4 f3=new FP4();
-
+		FP4[] FP4_4 = usqrFP4_4.get();
+		FP4 f0=FP4_4[0];f0.copy(a);
+		FP4 f1=FP4_4[1];f1.copy(b);
+		FP4 f2=FP4_4[2];f2.copy(a);
+		FP4 f3=FP4_4[3];f3.zero();
+		
 		norm();
 		f0.sqr();
 		f1.mul(c);
@@ -768,8 +803,9 @@ public final class FP12 {
 /* this=this^p using Frobenius */
 	public void frob(FP2 f)
 	{
-		FP2 f2=new FP2(f);
-		FP2 f3=new FP2(f);
+		FP2[] FP2_2 = frobFP2_2.get();
+		FP2 f2=FP2_2[0];f2.copy(f);
+		FP2 f3=FP2_2[1];f3.copy(f);
 
 		f2.sqr();
 		f3.mul(f2);
@@ -830,15 +866,17 @@ public final class FP12 {
 /* Note this is simple square and multiply, so not side-channel safe */
 	public FP12 pow(BIG e)
 	{
-		BIG e1=new BIG(e);
+		BIG[] BIG_2 = powBIG_2.get();
+		FP12[] FP12_2 = powFP12_2.get();
+		BIG e1=BIG_2[0]; e1.copy(e);
 		e1.norm();
-		BIG e3=new BIG(e1);
+		BIG e3=BIG_2[1]; e3.copy(e1);
 		e3.pmul(3);
 		e3.norm();
 
-		FP12 sf=new FP12(this);
+		FP12 sf=FP12_2[0]; sf.copy(this);
 		sf.norm();
-		FP12 w=new FP12(sf);
+		FP12 w=FP12_2[1]; w.copy(sf);
         if (e3.iszilch()) {
             w.one();
             return w;

--- a/core/src/main/java/org/miracl/core/ED25519/ECP.java
+++ b/core/src/main/java/org/miracl/core/ED25519/ECP.java
@@ -540,7 +540,7 @@ public final class ECP
 			FP C=FPw[0]; C.copy(x);
 			FP D=FPw[1]; D.copy(y);
 			FP H=FPw[2]; H.copy(z);
-			FP J=FPw[3]; // J.zero();
+			FP J=FPw[3];
 
 			x.mul(y); x.add(x); x.norm();
 			C.sqr();

--- a/core/src/test/java/org/radix/hyperscale/crypto/bls12381/BLS12381Benchmark.java
+++ b/core/src/test/java/org/radix/hyperscale/crypto/bls12381/BLS12381Benchmark.java
@@ -1,0 +1,222 @@
+package org.radix.hyperscale.crypto.bls12381;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.radix.hyperscale.crypto.CryptoException;
+import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.crypto.Signature.VerificationResult;
+
+/**
+ * A benchmark for BLS12381 operations.
+ */
+public class BLS12381Benchmark {
+    
+    // Number of messages to process
+    private static final int NUM_MESSAGES = 10_000;
+    
+    // Number of key pairs to generate
+    private static final int NUM_KEYS = 100;
+    
+    // Message size in bytes
+    private static final int MESSAGE_SIZE = 64;
+    
+    // Number of keys to aggregate
+    private static final int AGGREGATE_KEYS = 10;
+    
+    public static void main(String[] args) 
+    {
+        System.out.println("BLS12381 Benchmark");
+        System.out.println("=================");
+        System.out.println("Number of key pairs: " + NUM_KEYS);
+        System.out.println("Number of messages: " + NUM_MESSAGES);
+        System.out.println("Message size: " + MESSAGE_SIZE + " bytes");
+        System.out.println("Number of keys/signatures to aggregate: " + AGGREGATE_KEYS);
+        System.out.println();
+        
+        try 
+        {
+        	Thread.sleep(10000);
+        	
+            // Generate key pairs
+            long startKeyGen = System.nanoTime();
+            List<BLSKeyPair> keyPairs = generateKeyPairs(NUM_KEYS);
+            long endKeyGen = System.nanoTime();
+            
+            // Extract public keys
+            List<BLSPublicKey> publicKeys = new ArrayList<>();
+            for (BLSKeyPair keyPair : keyPairs)
+                publicKeys.add(keyPair.getPublicKey());
+            
+            // Generate messages
+            List<byte[]> digests = generateDigests(NUM_MESSAGES, MESSAGE_SIZE);
+            
+            // Perform signing benchmark
+            long startSigning = System.nanoTime();
+            List<BLSSignature> signatures = signMessages(digests, keyPairs);
+            long endSigning = System.nanoTime();
+            
+            // Perform verification benchmark
+            long startVerification = System.nanoTime();
+            boolean allVerified = verifySignatures(digests, signatures, keyPairs);
+            long endVerification = System.nanoTime();
+            
+            // Perform aggregation benchmark
+            long startAggregationBenchmark = System.nanoTime();
+            boolean allAggVerified = runAggregationBenchmark(keyPairs, NUM_MESSAGES / AGGREGATE_KEYS);
+            long endAggregationBenchmark = System.nanoTime();
+            
+            // Print results
+            double keyGenTimeMs = TimeUnit.NANOSECONDS.toMillis(endKeyGen - startKeyGen);
+            double signingTimeMs = TimeUnit.NANOSECONDS.toMillis(endSigning - startSigning);
+            double verificationTimeMs = TimeUnit.NANOSECONDS.toMillis(endVerification - startVerification);
+            double aggregationTimeMs = TimeUnit.NANOSECONDS.toMillis(endAggregationBenchmark - startAggregationBenchmark);
+            
+            System.out.println("Results:");
+            System.out.println("---------");
+            System.out.printf("Key Generation: %.2f ms total, %.2f ms per key%n", keyGenTimeMs, keyGenTimeMs / NUM_KEYS);
+            
+            System.out.printf("Signing: %.2f ms total, %.2f µs per message%n", signingTimeMs, signingTimeMs * 1000 / NUM_MESSAGES);
+            
+            System.out.printf("Verification: %.2f ms total, %.2f µs per message%n", verificationTimeMs, verificationTimeMs * 1000 / NUM_MESSAGES);
+            
+            System.out.printf("Aggregation (signing, aggregating, verifying): %.2f ms total, %.2f ms per batch%n", aggregationTimeMs, aggregationTimeMs / (NUM_MESSAGES / AGGREGATE_KEYS));
+            
+            System.out.println("All individual signatures verified: " + allVerified);
+            System.out.println("All aggregated signatures verified: " + allAggVerified);
+            
+            // Calculate operations per second
+            double signingsPerSecond = NUM_MESSAGES / (signingTimeMs / 1000);
+            double verificationsPerSecond = NUM_MESSAGES / (verificationTimeMs / 1000);
+            double aggregationsPerSecond = (NUM_MESSAGES / AGGREGATE_KEYS) / (aggregationTimeMs / 1000);
+            
+            System.out.println();
+            System.out.println("Performance:");
+            System.out.println("-----------");
+            System.out.printf("Signings per second: %.0f%n", signingsPerSecond);
+            System.out.printf("Verifications per second: %.0f%n", verificationsPerSecond);
+            System.out.printf("Aggregated operations per second: %.0f%n", aggregationsPerSecond);
+            
+        } 
+        catch (Exception e)
+        {
+            System.err.println("Error during benchmark: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+    
+    /**
+     * Generate multiple key pairs.
+     */
+    private static List<BLSKeyPair> generateKeyPairs(int count) 
+    {
+        List<BLSKeyPair> keyPairs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++)
+            keyPairs.add(new BLSKeyPair());
+        
+        return keyPairs;
+    }
+    
+    /**
+     * Generate random messages for benchmarking.
+     */
+    private static List<byte[]> generateDigests(int count, int size) 
+    {
+        List<byte[]> digests = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) 
+        {
+            byte[] message = new byte[size];
+            // Fill with pseudo-random data based on i
+            for (int j = 0; j < size; j++)
+                message[j] = (byte)((i * j) % 256);
+
+            digests.add(Hash.hash(message).toByteArray());
+        }
+        
+        return digests;
+    }
+    
+    /**
+     * Sign a list of messages.
+     */
+    private static List<BLSSignature> signMessages(List<byte[]> digests, List<BLSKeyPair> keyPairs) throws CryptoException 
+    {
+        List<BLSSignature> signatures = new ArrayList<>(digests.size());
+        for (int i = 0; i < digests.size(); i++) 
+        {
+            // Select a key pair based on message index, cycling through the available key pairs
+            BLSKeyPair keyPair = keyPairs.get(i % keyPairs.size());
+            BLSSignature signature = keyPair.getPrivateKey().sign(digests.get(i));
+            signature.setVerified(VerificationResult.UNVERIFIED);
+            signatures.add(signature);
+        }
+        
+        return signatures;
+    }
+    
+    /**
+     * Verify a list of signatures.
+     */
+    private static boolean verifySignatures(List<byte[]> digests, List<BLSSignature> signatures, List<BLSKeyPair> keyPairs) 
+    {
+        boolean allValid = true;
+        
+        for (int i = 0; i < digests.size(); i++) 
+        {
+            BLSKeyPair keyPair = keyPairs.get(i % keyPairs.size());
+            boolean valid = keyPair.getPublicKey().verify(digests.get(i), signatures.get(i));
+            if (valid == false) 
+            {
+                allValid = false;
+                System.err.println("Verification failed for message " + i);
+                break;
+            }
+        }
+        
+        return allValid;
+    }
+    
+    private static boolean runAggregationBenchmark(List<BLSKeyPair> keyPairs, int numBatches) throws CryptoException 
+    {
+        boolean allValid = true;
+        
+        for (int batchIdx = 0; batchIdx < numBatches; batchIdx++) 
+        {
+            // Generate a unique message for this batch
+            byte[] message = new byte[MESSAGE_SIZE];
+            for (int j = 0; j < MESSAGE_SIZE; j++)
+                message[j] = (byte)((batchIdx * j) % 256);
+            Hash digest = Hash.hash(message);
+            
+            // Have multiple keys sign the same message
+            List<BLSSignature> batchSignatures = new ArrayList<>();
+            List<BLSPublicKey> batchPublicKeys = new ArrayList<>();
+            
+            for (int i = 0; i < AGGREGATE_KEYS; i++) {
+                int keyIdx = (batchIdx * AGGREGATE_KEYS + i) % keyPairs.size();
+                BLSKeyPair keyPair = keyPairs.get(keyIdx);
+                
+                // Each key signs the same batch message
+                BLSSignature signature = keyPair.getPrivateKey().sign(digest);
+                batchSignatures.add(signature);
+                batchPublicKeys.add(keyPair.getPublicKey());
+            }
+            
+            // Aggregate the signatures and public keys
+            BLSSignature aggregatedSignature = BLS12381.aggregateSignatures(batchSignatures);
+            BLSPublicKey aggregatedPublicKey = BLS12381.aggregatePublicKey(batchPublicKeys);
+            
+            // Verify the aggregated signature
+            boolean valid = aggregatedPublicKey.verify(digest, aggregatedSignature);
+            if (valid == false) 
+            {
+                allValid = false;
+                System.err.println("Aggregated verification failed for batch " + batchIdx);
+                break;
+            }
+        }
+        
+        return allValid;
+    }
+}

--- a/core/src/test/java/org/radix/hyperscale/crypto/bls12381/BLS12381Test.java
+++ b/core/src/test/java/org/radix/hyperscale/crypto/bls12381/BLS12381Test.java
@@ -1,0 +1,297 @@
+package org.radix.hyperscale.crypto.bls12381;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.radix.hyperscale.crypto.CryptoException;
+import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.crypto.Signature.VerificationResult;
+
+/**
+ * Tests for the BLS12381 signature scheme implementation.
+ */
+public class BLS12381Test 
+{
+    /**
+     * Tests key pair generation.
+     */
+    @Test
+    public void testKeyPairGeneration() throws CryptoException 
+    {
+        // Generate a key pair
+        BLSKeyPair keyPair = new BLSKeyPair();
+        
+        // Check that the keys are not null
+        assertNotNull("Private key should not be null", keyPair.getPrivateKey());
+        assertNotNull("Public key should not be null", keyPair.getPublicKey());
+        
+        // Verify that the derived public key is valid
+        BLSPrivateKey privateKey = keyPair.getPrivateKey();
+        BLSPublicKey publicKey = keyPair.getPublicKey();
+        
+        // Check the key pair association
+        String message = "Hello, BLS12381!";
+        Hash digest = Hash.hash(message);
+        BLSSignature signature = privateKey.sign(digest);
+        signature.setVerified(VerificationResult.UNVERIFIED);
+
+        assertTrue("Signature verification should succeed with the corresponding public key", publicKey.verify(digest, signature));
+    }
+    
+    /**
+     * Tests signing and verification.
+     */
+    @Test
+    public void testSignAndVerify() throws CryptoException 
+    {
+        // Generate a key pair
+        BLSKeyPair keyPair = new BLSKeyPair();
+        
+        // Sign a message
+        String message = "Hello, BLS12381!";
+        Hash digest = Hash.hash(message);
+        BLSSignature signature = keyPair.getPrivateKey().sign(digest);
+        signature.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Verify the signature
+        boolean result = keyPair.getPublicKey().verify(digest, signature);
+        assertTrue("Signature verification should succeed", result);
+        signature.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Verify with a different message
+        String differentMessage = "Different message";
+        Hash differentDigest = Hash.hash(differentMessage);
+        result = keyPair.getPublicKey().verify(differentDigest, signature);
+        assertFalse("Signature verification should fail with a different message", result);
+        signature.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Generate another key pair
+        BLSKeyPair anotherKeyPair = new BLSKeyPair();
+        
+        // Verify with a different public key
+        result = anotherKeyPair.getPublicKey().verify(digest, signature);
+        assertFalse("Signature verification should fail with a different public key", result);
+    }
+    
+    /**
+     * Tests signature aggregation.
+     */
+    @Test
+    public void testSignatureAggregation() throws CryptoException 
+    {
+        // Generate multiple key pairs
+        int numKeys = 5;
+        List<BLSKeyPair> keyPairs = new ArrayList<>();
+        List<BLSPublicKey> publicKeys = new ArrayList<>();
+        List<BLSSignature> signatures = new ArrayList<>();
+        
+        for (int i = 0; i < numKeys; i++) 
+        {
+            keyPairs.add(new BLSKeyPair());
+            publicKeys.add(keyPairs.get(i).getPublicKey());
+        }
+        
+        // Sign the same message with all private keys
+        String message = "Message to be signed by multiple keys";
+        Hash digest = Hash.hash(message);
+        
+        for (int i = 0; i < numKeys; i++)
+        {
+        	BLSSignature signature = keyPairs.get(i).getPrivateKey().sign(digest);
+            signature.setVerified(VerificationResult.UNVERIFIED);
+        	signatures.add(signature);
+        }
+        
+        // Aggregate the signatures
+        BLSSignature aggregatedSignature = BLS12381.aggregateSignatures(signatures);
+        
+        // Aggregate the public keys
+        BLSPublicKey aggregatedPublicKey = BLS12381.aggregatePublicKey(publicKeys);
+        
+        // Verify the aggregated signature with the aggregated public key
+        boolean result = aggregatedPublicKey.verify(digest, aggregatedSignature);
+        assertTrue("Aggregated signature verification should succeed with aggregated public key", result);
+        aggregatedSignature.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Verify individual signatures with the corresponding public keys
+        for (int i = 0; i < numKeys; i++) 
+        {
+        	BLSSignature signature = signatures.get(i);
+            result = publicKeys.get(i).verify(digest, signature);
+            assertTrue("Individual signature verification should succeed", result);
+            signature.setVerified(VerificationResult.UNVERIFIED);
+        }
+    }
+    
+    /**
+     * Tests aggregation of signatures from different messages.
+     */
+    @Test
+    public void testDifferentMessageAggregation() throws CryptoException 
+    {
+        // Generate multiple key pairs
+        int numKeys = 3;
+        List<BLSKeyPair> keyPairs = new ArrayList<>();
+        List<BLSPublicKey> publicKeys = new ArrayList<>();
+        List<BLSSignature> signatures = new ArrayList<>();
+        
+        for (int i = 0; i < numKeys; i++) 
+        {
+            keyPairs.add(new BLSKeyPair());
+            publicKeys.add(keyPairs.get(i).getPublicKey());
+        }
+        
+        // Sign different messages with different keys
+        String[] messages = new String[numKeys];
+        for (int i = 0; i < numKeys; i++) 
+        {
+            messages[i] = "Message " + i;
+            Hash digest = Hash.hash(messages[i]);
+            BLSSignature signature = keyPairs.get(i).getPrivateKey().sign(digest);
+            signature.setVerified(VerificationResult.UNVERIFIED);
+            signatures.add(signature);
+        }
+        
+        // Aggregate the signatures
+        BLSSignature aggregatedSignature = BLS12381.aggregateSignatures(signatures);
+        
+        // Note: For different messages, we cannot simply verify with the aggregated public key
+        // The test here shows that individual verifications still work
+        for (int i = 0; i < numKeys; i++) 
+        {
+            Hash digest = Hash.hash(messages[i]);
+            BLSSignature signature = signatures.get(i);
+            boolean result = publicKeys.get(i).verify(digest, signature);
+            assertTrue("Individual signature verification should succeed", result);
+            signature.setVerified(VerificationResult.UNVERIFIED);
+        }
+    }
+    
+    /**
+     * Tests signature combination methods.
+     */
+    @Test
+    public void testSignatureCombination() throws CryptoException 
+    {
+        // Generate key pairs
+        BLSKeyPair keyPair1 = new BLSKeyPair();
+        BLSKeyPair keyPair2 = new BLSKeyPair();
+        
+        // Sign the same message
+        String  message = "Test message for combination";
+        Hash digest = Hash.hash(message);
+        BLSSignature signature1 = keyPair1.getPrivateKey().sign(digest);
+        signature1.setVerified(VerificationResult.UNVERIFIED);
+        BLSSignature signature2 = keyPair2.getPrivateKey().sign(digest);
+        signature2.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Combine signatures using the combine method
+        BLSSignature combinedSignature = signature1.combine(signature2);
+        
+        // Create a list and use the list-based combine method
+        List<BLSSignature> signatureList = new ArrayList<>();
+        signatureList.add(signature1);
+        signatureList.add(signature2);
+        
+        BLSSignature aggregatedSignature = BLS12381.aggregateSignatures(signatureList);
+        
+        // The combined signature should be the same as the aggregated signature
+        assertArrayEquals("Combined signature should be equal to aggregated signature", combinedSignature.toByteArray(), aggregatedSignature.toByteArray());
+        
+        // Combine public keys
+        BLSPublicKey publicKey1 = keyPair1.getPublicKey();
+        BLSPublicKey publicKey2 = keyPair2.getPublicKey();
+        
+        BLSPublicKey combinedPublicKey = publicKey1.combine(publicKey2);
+        
+        // Create a list and use the list-based combine method
+        List<BLSPublicKey> publicKeyList = new ArrayList<>();
+        publicKeyList.add(publicKey1);
+        publicKeyList.add(publicKey2);
+        
+        BLSPublicKey aggregatedPublicKey = BLS12381.aggregatePublicKey(publicKeyList);
+        
+        // The combined public key should be the same as the aggregated public key
+        assertArrayEquals("Combined public key should be equal to aggregated public key", combinedPublicKey.toByteArray(), aggregatedPublicKey.toByteArray());
+        
+        // Verify with the combined public key
+        boolean result = combinedPublicKey.verify(digest, combinedSignature);
+        assertTrue("Verification with combined keys should succeed", result);
+    }
+    
+    /**
+     * Tests signature reduction.
+     */
+    @Test
+    public void testSignatureReduction() throws CryptoException 
+    {
+        // Generate key pairs
+        BLSKeyPair keyPair1 = new BLSKeyPair();
+        BLSKeyPair keyPair2 = new BLSKeyPair();
+        
+        // Sign the same message
+        String message = "Test message for reduction";
+        Hash digest = Hash.hash(message);
+        BLSSignature signature1 = keyPair1.getPrivateKey().sign(digest);
+        signature1.setVerified(VerificationResult.UNVERIFIED);
+        BLSSignature signature2 = keyPair2.getPrivateKey().sign(digest);
+        signature2.setVerified(VerificationResult.UNVERIFIED);
+        
+        // Combine signatures
+        BLSSignature combinedSignature = signature1.combine(signature2);
+        
+        // Reduce the combined signature by removing signature2
+        BLSSignature reducedSignature = combinedSignature.reduce(signature2);
+        
+        // The reduced signature should be equal to signature1
+        assertArrayEquals("Reduced signature should be equal to signature1", reducedSignature.toByteArray(), signature1.toByteArray());
+    }
+    
+    /**
+     * Tests serialization/deserialization of keys and signatures.
+     */
+    @Test
+    public void testSerialization() throws CryptoException 
+    {
+        // Generate a key pair
+        BLSKeyPair keyPair = new BLSKeyPair();
+        
+        // Get byte representations
+        byte[] privateKeyBytes = keyPair.getPrivateKey().toByteArray();
+        byte[] publicKeyBytes = keyPair.getPublicKey().toByteArray();
+        
+        // Recreate from bytes
+        BLSPrivateKey recreatedPrivateKey = BLSPrivateKey.from(privateKeyBytes);
+        BLSPublicKey recreatedPublicKey = BLSPublicKey.from(publicKeyBytes);
+        
+        // Sign a message with both original and recreated private keys
+        String message = "Test serialization";
+        Hash digest = Hash.hash(message);
+        BLSSignature originalSignature = keyPair.getPrivateKey().sign(digest);
+        BLSSignature recreatedSignature = recreatedPrivateKey.sign(digest);
+        
+        // Get byte representations of signatures
+        byte[] originalSignatureBytes = originalSignature.toByteArray();
+        byte[] recreatedSignatureBytes = recreatedSignature.toByteArray();
+        
+        // Recreate signatures from bytes
+        BLSSignature deserializedOriginalSignature = BLSSignature.from(originalSignatureBytes);
+        BLSSignature deserializedRecreatedSignature = BLSSignature.from(recreatedSignatureBytes);
+        
+        // Verify all permutations
+        assertTrue("Original public key should verify original signature", keyPair.getPublicKey().verify(digest, originalSignature));
+        
+        assertTrue("Recreated public key should verify original signature", recreatedPublicKey.verify(digest, originalSignature));
+        
+        assertTrue("Original public key should verify recreated signature", keyPair.getPublicKey().verify(digest, recreatedSignature));
+        
+        assertTrue("Recreated public key should verify recreated signature", recreatedPublicKey.verify(digest, recreatedSignature));
+        
+        assertTrue("Original public key should verify deserialized original signature", keyPair.getPublicKey().verify(digest, deserializedOriginalSignature));
+        
+        assertTrue("Original public key should verify deserialized recreated signature", keyPair.getPublicKey().verify(digest, deserializedRecreatedSignature));
+    }
+}


### PR DESCRIPTION
A number of methods when calculating field points on the BLS curve perform many temporary variable allocations.

Those in the current critical path have been modified to use thread local working variables.

Perhaps another 20% reduction in working memory use remaining in the non-critical path functions.

Overall performance increase of approx 10% when verifying and signing.