### PR TITLE
Liveness drift patch

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/ledger/BlockHandler.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/BlockHandler.java
@@ -65,7 +65,6 @@ import org.radix.hyperscale.logging.Logging;
 import org.radix.hyperscale.network.AbstractConnection;
 import org.radix.hyperscale.network.GossipFetcher;
 import org.radix.hyperscale.network.GossipFilter;
-import org.radix.hyperscale.network.GossipHandler;
 import org.radix.hyperscale.network.GossipInventory;
 import org.radix.hyperscale.network.GossipReceiver;
 import org.radix.hyperscale.network.MessageProcessor;
@@ -1261,7 +1260,7 @@ public class BlockHandler implements Service
 
 			// Progress interval & delay
 			final long targetRoundDuration = Math.max(Constants.MINIMUM_ROUND_DURATION_MILLISECONDS, Configuration.getDefault().get("ledger.liveness.delay", 0));
-			final long roundDelayDuration = (targetRoundDuration-progressRound.getDuration())+Math.max(progressRound.driftMilli(), 0);
+			final long roundDelayDuration = (targetRoundDuration-progressRound.getDuration())+Math.min(progressRound.driftMilli()/2, 0);
 			
 			// Too fast
 			if (roundDelayDuration > 0 && progressRound.driftClock() == 0)

--- a/core/src/main/java/org/radix/hyperscale/ledger/Ledger.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/Ledger.java
@@ -949,8 +949,10 @@ public final class Ledger implements Service, LedgerInterface
     				return;
     			
     			// Reasons NOT to ask for all the pool inventories
-    			if (Ledger.this.context.getNode().isSynced() == false || 
-    				Ledger.this.getHead().getHash().equals(Universe.getDefault().getGenesis().getHash()) == false || 
+    			if (Ledger.this.context.getNode().isSynced() == false)
+    				return;
+    			
+    			if (Ledger.this.getHead().getHash().equals(Universe.getDefault().getGenesis().getHash()) == false && 
     				Ledger.this.getHead().getHeight() >= event.getConnection().getNode().getHead().getHeight() - Constants.OOS_TRIGGER_LIMIT_BLOCKS)
     				return;
 


### PR DESCRIPTION
Changes to progress round and liveness to promote a "tighter" synchronization of replicas in the same shard group when network conditions are healthy.

Helps with a more consistent round interval and shaves a little of finality.