### PR TITLE
Improve atom sig management

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/WebSocketService.java
+++ b/core/src/main/java/org/radix/hyperscale/WebSocketService.java
@@ -166,7 +166,7 @@ public final class WebSocketService extends WebSocketServer
 			else
 				throw new UnsupportedOperationException("State decision of type "+event.getDecision()+" is not supported");
 			
-			eventJSON.put("atom", Serialization.getInstance().toJsonObject(event.getAtom(), Output.API));
+			eventJSON.put("atom", Serialization.getInstance().toJsonObject(event.getPendingAtom().getAtom(), Output.API));
 			eventJSON.put("certificate", Serialization.getInstance().toJsonObject(event.getPendingAtom().getCertificate(), Output.API));
 			WebSocketService.this.broadcast(eventJSON.toString());
 		}
@@ -179,7 +179,7 @@ public final class WebSocketService extends WebSocketServer
 
 			JSONObject eventJSON = new JSONObject();
 			eventJSON.put("type", "exception");
-			eventJSON.put("atom", Serialization.getInstance().toJsonObject(event.getAtom(), Output.API));
+			eventJSON.put("atom", Serialization.getInstance().toJsonObject(event.getPendingAtom().getAtom(), Output.API));
 			eventJSON.put("error", event.getException().toString());
 			WebSocketService.this.broadcast(eventJSON.toString());
 		}

--- a/core/src/main/java/org/radix/hyperscale/crypto/Signature.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/Signature.java
@@ -2,7 +2,9 @@ package org.radix.hyperscale.crypto;
 
 import java.util.Arrays;
 
-public abstract class Signature
+import org.radix.hyperscale.serialization.Polymorphic;
+
+public abstract class Signature implements Polymorphic
 {
 	public enum VerificationResult 
 	{

--- a/core/src/main/java/org/radix/hyperscale/ledger/AtomHandler.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/AtomHandler.java
@@ -404,8 +404,6 @@ public class AtomHandler implements Service, LedgerInterface
 						continue;
 					}
 
-					// TODO not ideal to do this BEFORE validation as it will create a state-machine
-					//		potential DDOS-like vector if attacker simply floods invalid transactions
 					pendingAtom.setAtom(atom);
 				
 					if (atom.getHash().leadingZeroBits() < Constants.MIN_PRIMITIVE_POW_DIFFICULTY && atom.hasAuthority(Universe.getDefault().getCreator()) == false)

--- a/core/src/main/java/org/radix/hyperscale/ledger/PendingAtom.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/PendingAtom.java
@@ -261,8 +261,6 @@ public final class PendingAtom implements Hashable, StateAddressable
 			this.atom = atom;
 			this.witnessedAt = Time.getSystemTime();
 			
-			this.stateMachine = new StateMachine(this.context, this, this.pendingStates);
-			
 			// Accept timeout is a baseline constant scaled log(quantity of instructions).
 			// More instructions generally means more shards are touched, therefore more latency for 
 			// all required shard groups to be ready to accept if there is some state contention.
@@ -447,7 +445,7 @@ public final class PendingAtom implements Hashable, StateAddressable
 		return this.forcePrepareTimeout;
 	}
 	
-	void prepare() throws IOException, StateMachinePreparationException
+	void prepare() throws IOException, StateMachinePreparationException, ManifestException
 	{
 		if (this.forcePrepareTimeout)
 			return;
@@ -460,6 +458,7 @@ public final class PendingAtom implements Hashable, StateAddressable
 			if (this.status.after(State.NONE))
 				throw new IllegalStateException("Atom is already PREPARED");
 
+			this.stateMachine = new StateMachine(this.context, this, this.pendingStates);
 			this.stateMachine.prepare();
 			
 			this.prepareTimeoutAt = -1;

--- a/core/src/main/java/org/radix/hyperscale/ledger/ValidatorHandler.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/ValidatorHandler.java
@@ -21,7 +21,7 @@ import org.radix.hyperscale.collections.LRUCacheMap;
 import org.radix.hyperscale.concurrency.MonitoredReadWriteLock;
 import org.radix.hyperscale.crypto.Hash;
 import org.radix.hyperscale.crypto.Identity;
-import org.radix.hyperscale.crypto.Key;
+import org.radix.hyperscale.crypto.PublicKey;
 import org.radix.hyperscale.database.DatabaseException;
 import org.radix.hyperscale.events.EventListener;
 import org.radix.hyperscale.events.SynchronousEventListener;
@@ -283,7 +283,7 @@ public final class ValidatorHandler implements Service
 		}
 	}
 	
-	public <T extends Key> List<T> getKeys(final Bloom identityBloom) throws IOException
+	public <T extends PublicKey<?>> List<T> getKeys(final Bloom identityBloom) throws IOException
 	{
 		Objects.requireNonNull(identityBloom, "Identity bloom is null");
 

--- a/core/src/main/java/org/radix/hyperscale/ledger/events/AtomEvent.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/events/AtomEvent.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 
 import org.radix.hyperscale.events.Event;
 import org.radix.hyperscale.ledger.PendingAtom;
-import org.radix.hyperscale.ledger.primitives.Atom;
 
 abstract class AtomEvent implements Event 
 {
@@ -18,10 +17,5 @@ abstract class AtomEvent implements Event
 	public final PendingAtom getPendingAtom()
 	{
 		return this.pendingAtom;
-	}
-
-	public final Atom getAtom()
-	{
-		return this.pendingAtom.getAtom();
 	}
 }

--- a/core/src/main/java/org/radix/hyperscale/ledger/primitives/Atom.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/primitives/Atom.java
@@ -34,7 +34,6 @@ import org.radix.hyperscale.serialization.DsonOutput.Output;
 import org.radix.hyperscale.utils.Numbers;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.annotations.VisibleForTesting;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SerializerId2("ledger.atom")
@@ -216,6 +215,7 @@ public final class Atom extends ExtendedObject implements Primitive
 	
 	private volatile boolean immutable = false;
 	
+	@SuppressWarnings("unused")
 	private Atom()
 	{
 		super();


### PR DESCRIPTION
Atoms had a "clunky" signature management pattern.  They now support both EC and BLS properly, and can support future types without modification assuming that existing signature design patterns are adhered to for new primitives.  

The improvement required a special case modification to the DSON deserializers.