### PR TITLE
Gossip queues & heatbeat

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/network/messages/NodeMessage.java
+++ b/core/src/main/java/org/radix/hyperscale/network/messages/NodeMessage.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * 
  */
 @SerializerId2("message.node")
-public class NodeMessage extends Message
+public final class NodeMessage extends Message
 {
 	@JsonProperty("node")
 	@DsonOutput(Output.ALL)

--- a/core/src/main/java/org/radix/hyperscale/network/messages/PeerPingMessage.java
+++ b/core/src/main/java/org/radix/hyperscale/network/messages/PeerPingMessage.java
@@ -1,6 +1,5 @@
 package org.radix.hyperscale.network.messages;
 
-import org.radix.hyperscale.node.Node;
 import org.radix.hyperscale.serialization.DsonOutput;
 import org.radix.hyperscale.serialization.SerializerId2;
 import org.radix.hyperscale.serialization.DsonOutput.Output;
@@ -8,7 +7,7 @@ import org.radix.hyperscale.serialization.DsonOutput.Output;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SerializerId2("network.message.ping")
-public final class PeerPingMessage extends NodeMessage
+public final class PeerPingMessage extends Message
 {
 	@JsonProperty("nonce")
 	@DsonOutput(Output.ALL)
@@ -19,10 +18,8 @@ public final class PeerPingMessage extends NodeMessage
 		super();
 	}
 
-	public PeerPingMessage(final Node node, final long nonce)
+	public PeerPingMessage(final long nonce)
 	{
-		super(node);
-		
 		this.nonce = nonce;
 	}
 

--- a/core/src/main/java/org/radix/hyperscale/network/messages/PeerPongMessage.java
+++ b/core/src/main/java/org/radix/hyperscale/network/messages/PeerPongMessage.java
@@ -1,6 +1,5 @@
 package org.radix.hyperscale.network.messages;
 
-import org.radix.hyperscale.node.Node;
 import org.radix.hyperscale.serialization.DsonOutput;
 import org.radix.hyperscale.serialization.SerializerId2;
 import org.radix.hyperscale.serialization.DsonOutput.Output;
@@ -8,7 +7,7 @@ import org.radix.hyperscale.serialization.DsonOutput.Output;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SerializerId2("network.message.pong")
-public final class PeerPongMessage extends NodeMessage
+public final class PeerPongMessage extends Message
 {
 	@JsonProperty("nonce")
 	@DsonOutput(Output.ALL)
@@ -21,10 +20,8 @@ public final class PeerPongMessage extends NodeMessage
 		this.nonce = 0l;
 	}
 
-	public PeerPongMessage(final Node node, final long nonce)
+	public PeerPongMessage(final long nonce)
 	{
-		super(node);
-
 		this.nonce = nonce;
 	}
 


### PR DESCRIPTION
The broadcast and delivery queues for priority and urgent items were insufficient and could lead to starvation.

Pinp/pong heartbeat carried a large "node" object which is now unnecessary and consumed a significant amount of bandwidth to deliver.