### PR TITLE
Minor search refactor giving more control over timeouts

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/Constants.java
+++ b/core/src/main/java/org/radix/hyperscale/Constants.java
@@ -28,8 +28,8 @@ public final class Constants
 	// GOSSIP
 	public static final int 	BROADCAST_POLL_TIMEOUT = 50;
 	public static final int 	MAX_PUSH_INVENTORY_ITEMS = 32;
-	public static final int 	MAX_BROADCAST_INVENTORY_ITEMS = 256;
-	public static final int 	MAX_REQUEST_INVENTORY_ITEMS = 256;
+	public static final int 	MAX_BROADCAST_INVENTORY_ITEMS = 128;
+	public static final int 	MAX_REQUEST_INVENTORY_ITEMS = 128;
 	public static final int 	MAX_FETCH_INVENTORY_ITEMS = 32;
 	public static final int 	INVENTORY_TRANSMIT_AT_SIZE = 1<<20;	// Transmit if size is 1M or greater
 	public static final int 	MIN_GOSSIP_REQUEST_TIMEOUT_MILLISECONDS = 5000;
@@ -55,10 +55,10 @@ public final class Constants
 	// ATOMS
 	public static final int 	ATOM_DISCARD_AT_PENDING_LIMIT = 50000;
 	public static final int 	ATOM_PREPARE_TIMEOUT_SECONDS = 5;
-	public static final int 	ATOM_ACCEPT_TIMEOUT_SECONDS = 10;
-	public static final int 	ATOM_EXECUTE_LATENT_SECONDS = 10;			
-	public static final int 	ATOM_EXECUTE_TIMEOUT_SECONDS = 20;			
-	public static final int 	ATOM_COMMIT_TIMEOUT_SECONDS = 20;
+	public static final int 	ATOM_ACCEPT_TIMEOUT_SECONDS = 15;
+	public static final int 	ATOM_EXECUTE_LATENT_SECONDS = 15;			
+	public static final int 	ATOM_EXECUTE_TIMEOUT_SECONDS = 30;			
+	public static final int 	ATOM_COMMIT_TIMEOUT_SECONDS = 30;
 	
 	// SYNC THRESHOLDS
 	public static final int     SYNC_BROADCAST_INTERVAL_MS = 1000;
@@ -71,6 +71,9 @@ public final class Constants
 	public static final long 	VOTE_POWER_BOOTSTRAP = 1000l;
 	public static final int 	VOTE_POWER_PROPOSAL_REWARD = 1;
 	public static final int 	VOTE_POWER_MATURITY_EPOCHS = 2;
+	
+	// SEARCH
+	public static final long 	SEARCH_TIMEOUT_SECONDS = 10;
 	
 	private Constants() {}
 }

--- a/core/src/main/java/org/radix/hyperscale/console/StateMachine.java
+++ b/core/src/main/java/org/radix/hyperscale/console/StateMachine.java
@@ -13,6 +13,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
+import org.radix.hyperscale.Constants;
 import org.radix.hyperscale.Context;
 import org.radix.hyperscale.Universe;
 import org.radix.hyperscale.apps.SimpleWallet;
@@ -277,8 +278,9 @@ public class StateMachine extends Function
 				decodedSubstateScope = ((String) decodedSubstateScope).toLowerCase();
 			
 			final StateAddress stateAddress = StateAddress.from(substateContext, Hash.valueOf(decodedSubstateScope));
-			final Future<SubstateSearchResponse> searchFuture = context.getLedger().get(new SubstateSearchQuery(stateAddress, Isolation.COMMITTED));
-			final SubstateSearchResponse searchResult = searchFuture.get(5, TimeUnit.SECONDS);
+			final SubstateSearchQuery substateSearchQuery = new SubstateSearchQuery(stateAddress, Isolation.COMMITTED);
+			final Future<SubstateSearchResponse> searchSearchFuture = context.getLedger().get(substateSearchQuery, Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final SubstateSearchResponse searchResult = searchSearchFuture.get(Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 			if (searchResult.getResult() == null) 
 			{
 				printStream.println("Substate "+substateContext+":"+substateScope+" mapping to "+stateAddress+" not found");

--- a/core/src/main/java/org/radix/hyperscale/console/Tokens.java
+++ b/core/src/main/java/org/radix/hyperscale/console/Tokens.java
@@ -11,6 +11,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.json.JSONObject;
+import org.radix.hyperscale.Constants;
 import org.radix.hyperscale.Context;
 import org.radix.hyperscale.Universe;
 import org.radix.hyperscale.apps.SimpleWallet;
@@ -55,7 +56,8 @@ public class Tokens extends Function
 		{
 			final String ISO = commandLine.getOptionValue("balance", "CASSIE");
 
-			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase()))));
+			final SubstateSearchQuery tokenSearchQuery = new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase())));
+			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(tokenSearchQuery, Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(10, TimeUnit.SECONDS);
 			if (tokenSearchResult.getResult() == null)
 			{
@@ -113,8 +115,9 @@ public class Tokens extends Function
 			final UInt256 amount = UInt256.from(options[0]);
 			final String ISO = options[1];
 			
-			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase()))));
-			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(10, TimeUnit.SECONDS);
+			final SubstateSearchQuery tokenSearchQuery = new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase())));
+			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(tokenSearchQuery, Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 			if (tokenSearchResult.getResult() == null)
 			{
 				printStream.println("Token "+ISO+" not found");
@@ -139,8 +142,9 @@ public class Tokens extends Function
 		{
 			final String ISO = commandLine.getOptionValue("debits", "CASSIE");
 			
-			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase()))));
-			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(10, TimeUnit.SECONDS);
+			final SubstateSearchQuery tokenSearchQuery = new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase())));
+			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(tokenSearchQuery, Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 			if (tokenSearchResult.getResult() == null)
 			{
 				printStream.println("Token "+ISO+" not found");
@@ -163,8 +167,9 @@ public class Tokens extends Function
 		{
 			final String ISO = commandLine.getOptionValue("credits", "CASSIE");
 			
-			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase()))));
-			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(10, TimeUnit.SECONDS);
+			final SubstateSearchQuery tokenSearchQuery = new SubstateSearchQuery(StateAddress.from(TokenComponent.class, Hash.valueOf(ISO.toLowerCase())));
+			final Future<SubstateSearchResponse> tokenSearchFuture = context.getLedger().get(tokenSearchQuery, Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final SubstateSearchResponse tokenSearchResult = tokenSearchFuture.get(Constants.SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 			if (tokenSearchResult.getResult() == null)
 			{
 				printStream.println("Token "+ISO+" not found");

--- a/core/src/main/java/org/radix/hyperscale/ledger/Ledger.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/Ledger.java
@@ -64,7 +64,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.Subscribe;
 import com.sleepycat.je.OperationStatus;
 
-public final class Ledger implements Service, LedgerInterface
+public final class Ledger implements Service, LedgerSearchInterface
 {
 	private static final Logger ledgerLog = Logging.getLogger("ledger");
 	
@@ -570,21 +570,21 @@ public final class Ledger implements Service, LedgerInterface
 	}
 
 	@Override
-	public Future<AssociationSearchResponse> get(final AssociationSearchQuery query)
+	public Future<AssociationSearchResponse> get(final AssociationSearchQuery query, final long timeout, final TimeUnit timeUnit)
 	{
-		return this.ledgerSearch.get(query);
+		return this.ledgerSearch.get(query, timeout, timeUnit);
 	}
 
 	@Override
-	public Future<SubstateSearchResponse> get(SubstateSearchQuery query)
+	public Future<SubstateSearchResponse> get(SubstateSearchQuery query, final long timeout, final TimeUnit timeUnit)
 	{
-		return this.ledgerSearch.get(query);
+		return this.ledgerSearch.get(query, timeout, timeUnit);
 	}
 	
 	@Override
-	public Future<PrimitiveSearchResponse> get(PrimitiveSearchQuery query)
+	public Future<PrimitiveSearchResponse> get(PrimitiveSearchQuery query, final long timeout, final TimeUnit timeUnit)
 	{
-		return this.ledgerSearch.get(query);
+		return this.ledgerSearch.get(query, timeout, timeUnit);
 	}
 	
 	boolean isSynced()
@@ -947,7 +947,7 @@ public final class Ledger implements Service, LedgerInterface
 						case INTR: superText = ""; break;
 						case SOFT: superText = "soft super"; break;
 						case HARD: superText = "hard super"; break;
-						default: superText = "unknown";
+						default: superText = blockCommittedEvent.getPendingBlock().isCommittable() ? "committable" : "unknown";
 					}
 					
 					ledgerLog.info(Ledger.this.context.getName()+": Committed "+superText+" block with "+blockCommittedEvent.getPendingBlock().getHeader().getInventorySize(InventoryType.ACCEPTED)+" atoms "+

--- a/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearch.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearch.java
@@ -54,7 +54,7 @@ import org.radix.hyperscale.serialization.SerializerId2;
  * @author Dan
  *
  */
-final class LedgerSearch implements Service, LedgerInterface
+final class LedgerSearch implements Service, LedgerSearchInterface
 {
 	private static final Logger searchLog = Logging.getLogger("search");
 	
@@ -617,7 +617,7 @@ final class LedgerSearch implements Service, LedgerInterface
 	}
 
 	@Override
-	public Future<PrimitiveSearchResponse> get(final PrimitiveSearchQuery query) 
+	public Future<PrimitiveSearchResponse> get(final PrimitiveSearchQuery query, final long timeout, final TimeUnit timeUnit) 
 	{
 		ShardGroupID localShardGroupID = ShardMapper.toShardGroup(this.context.getNode().getIdentity(), this.context.getLedger().numShardGroups());
 		try
@@ -627,7 +627,7 @@ final class LedgerSearch implements Service, LedgerInterface
 				PrimitiveSearchTask primitiveSearchTask = this.primitiveSearchTasks.get(query.getHash());
 				if (primitiveSearchTask == null)
 				{					
-					primitiveSearchTask = new PrimitiveSearchTask(query, 5, TimeUnit.SECONDS);
+					primitiveSearchTask = new PrimitiveSearchTask(query, timeout, timeUnit);
 					this.primitiveSearchTasks.put(query.getHash(), primitiveSearchTask);
 					Executor.getInstance().schedule(primitiveSearchTask);
 					
@@ -689,7 +689,7 @@ final class LedgerSearch implements Service, LedgerInterface
 	}
 
 	@Override
-	public Future<SubstateSearchResponse> get(final SubstateSearchQuery query)
+	public Future<SubstateSearchResponse> get(final SubstateSearchQuery query, final long timeout, final TimeUnit timeUnit)
 	{
 		try
 		{
@@ -719,7 +719,7 @@ final class LedgerSearch implements Service, LedgerInterface
 
 				AtomicBoolean isExisting = new AtomicBoolean(true);
 				SubstateSearchTask substateSearchTask = this.substateSearchTasks.computeIfAbsent(query.getHash(), k -> {
-					SubstateSearchTask newSubstateSearchTask = new SubstateSearchTask(query, 5, TimeUnit.SECONDS); 
+					SubstateSearchTask newSubstateSearchTask = new SubstateSearchTask(query, timeout, timeUnit); 
 					Executor.getInstance().schedule(newSubstateSearchTask);
 					isExisting.set(false);
 					return newSubstateSearchTask;
@@ -754,7 +754,7 @@ final class LedgerSearch implements Service, LedgerInterface
 	}
 	
 	@Override
-	public Future<AssociationSearchResponse> get(final AssociationSearchQuery query)
+	public Future<AssociationSearchResponse> get(final AssociationSearchQuery query, final long timeout, final TimeUnit timeUnit)
 	{
 		ShardGroupID localShardGroupID = ShardMapper.toShardGroup(this.context.getNode().getIdentity(), this.context.getLedger().numShardGroups());
 		try
@@ -764,7 +764,7 @@ final class LedgerSearch implements Service, LedgerInterface
 				AssociationSearchTask associationSearchTask = this.associationSearchTasks.get(query.getHash());
 				if (associationSearchTask == null)
 				{					
-					associationSearchTask = new AssociationSearchTask(query, 5, TimeUnit.SECONDS);
+					associationSearchTask = new AssociationSearchTask(query, timeout, timeUnit);
 					this.associationSearchTasks.put(associationSearchTask.getQuery().getHash(), associationSearchTask);
 					Executor.getInstance().schedule(associationSearchTask);
 

--- a/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearchInterface.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearchInterface.java
@@ -1,0 +1,13 @@
+package org.radix.hyperscale.ledger;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public interface LedgerSearchInterface
+{
+	public Future<PrimitiveSearchResponse> get(final PrimitiveSearchQuery query, final long timeout, final TimeUnit timeunit);
+
+	public Future<SubstateSearchResponse> get(final SubstateSearchQuery query, final long timeout, final TimeUnit timeunit);
+	
+	public Future<AssociationSearchResponse> get(final AssociationSearchQuery query, final long timeout, final TimeUnit timeunit);
+}

--- a/core/src/main/java/org/radix/hyperscale/ledger/primitives/Atom.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/primitives/Atom.java
@@ -258,6 +258,11 @@ public final class Atom extends ExtendedObject implements Primitive
 		return Collections.unmodifiableList(this.manifest);
 	}
 	
+	public int getManifestSize()
+	{
+		return this.manifest.size();
+	}
+
 	public boolean isSealed()
 	{
 		return this.signatures.isEmpty() == false;

--- a/core/src/main/java/org/radix/hyperscale/tools/spam/Spammer.java
+++ b/core/src/main/java/org/radix/hyperscale/tools/spam/Spammer.java
@@ -309,7 +309,8 @@ public abstract class Spammer extends Executable
 			for (final Atom atom : pendingAtoms)
 			{
 				final SubstateSearchQuery query = new SubstateSearchQuery(StateAddress.from(Atom.class, atom.getHash()));
-				final Future<SubstateSearchResponse> response = Context.get().getLedger().get(query);
+				final long timeout = Constants.ATOM_ACCEPT_TIMEOUT_SECONDS + (long) (Constants.ATOM_ACCEPT_TIMEOUT_SECONDS * Math.log(atom.getManifestSize()));
+				final Future<SubstateSearchResponse> response = Context.get().getLedger().get(query, timeout, TimeUnit.SECONDS);
 				searchFutures.add(response);
 			}
 			
@@ -379,7 +380,8 @@ public abstract class Spammer extends Executable
 	private boolean isAtomCompleted(final Atom atom) throws InterruptedException, ExecutionException
 	{
 		final SubstateSearchQuery query = new SubstateSearchQuery(StateAddress.from(Atom.class, atom.getHash()));
-		final Future<SubstateSearchResponse> response = Context.get().getLedger().get(query);
+		final long timeout = Constants.ATOM_ACCEPT_TIMEOUT_SECONDS + (long) (Constants.ATOM_ACCEPT_TIMEOUT_SECONDS * Math.log(atom.getManifestSize()));
+		final Future<SubstateSearchResponse> response = Context.get().getLedger().get(query, timeout, TimeUnit.SECONDS);
 		final SubstateCommit result = response.get().getResult();
 		if (result != null && result.getSubstate().get(NativeField.CERTIFICATE) != null)
 			return true;


### PR DESCRIPTION
Lack of timeout control for search queries causing some issues.

Generally two types of search query:  
Lookups, which are fast.
Commit confirms, slower depending on complexity of transaction.

In the second case, hard coded timeout was too short for complex swaps, tripping the timeout even though the transaction was committed.