### PR TITLE
Crypto updates

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/collections/Bloom.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/Bloom.java
@@ -374,8 +374,8 @@ public class Bloom extends Serializable
 
     	synchronized(this)
     	{
-			for (int hash : hashes)
-				bitset.set(Math.abs(hash % bitSetSize), true);
+			for (int i = 0 ; i < hashes.length ; i++)
+				bitset.set(Math.abs(hashes[i] % bitSetSize), true);
        
 			numberOfAddedElements ++;
         }
@@ -395,9 +395,9 @@ public class Bloom extends Serializable
         
     	synchronized(this)
     	{
-	        for (int hash : hashes) 
+			for (int i = 0 ; i < hashes.length ; i++)
 	        {
-	            if (!bitset.get(Math.abs(hash % bitSetSize)))
+	            if (bitset.get(Math.abs(hashes[i] % bitSetSize)) == false)
 	                return false;
 	        }
         }

--- a/core/src/main/java/org/radix/hyperscale/crypto/bls12381/BLS12381.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/bls12381/BLS12381.java
@@ -51,7 +51,7 @@ public final class BLS12381
 		 * The signature is hash point in G1 multiplied by the private key.
 		 */
 		G1Point sig = privateKey.sign(hashInGroup1);
-		return new BLSSignature(sig);
+		return BLSSignature.from(sig);
 	}
 
 	/**

--- a/core/src/main/java/org/radix/hyperscale/crypto/bls12381/BLSPublicKey.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/bls12381/BLSPublicKey.java
@@ -45,7 +45,7 @@ public final class BLSPublicKey extends PublicKey<BLSSignature>
 	}
 	
 	private byte[] bytes;
-	private G2Point point;
+	private volatile G2Point point;
 	
 	private transient Identity identity;
 
@@ -61,7 +61,6 @@ public final class BLSPublicKey extends PublicKey<BLSSignature>
 		Numbers.isZero(bytes.length, "Bytes length is zero");
 		
 		this.bytes = Arrays.copyOfRange(bytes, offset, bytes.length);
-		this.point = G2Point.fromBytes(this.bytes);
 	}
 
 	BLSPublicKey(final G2Point point) 
@@ -97,9 +96,12 @@ public final class BLSPublicKey extends PublicKey<BLSSignature>
 		return new BLSPublicKey(g2Point().add(publicKey.g2Point()));
 	}
 
-  	G2Point g2Point() 
+	synchronized G2Point g2Point() 
   	{
-  		return this.point;
+		if (this.point == null)
+			this.point = G2Point.fromBytes(this.bytes);
+
+		return this.point;
   	}
   	
 	public synchronized Identity getIdentity()

--- a/core/src/main/java/org/radix/hyperscale/crypto/ed25519/EDKeyPair.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/ed25519/EDKeyPair.java
@@ -17,6 +17,8 @@ import org.radix.hyperscale.crypto.Signature.VerificationResult;
 
 import com.google.common.collect.ImmutableSet;
 
+import io.netty.util.internal.ThreadLocalRandom;
+
 /**
  * Asymmetric EC key pair provider fixed to curve 'secp256k1'.
  */
@@ -95,6 +97,18 @@ public final class EDKeyPair extends KeyPair<EDPrivateKey, EDPublicKey, EDSignat
 			}
 		}
 	}
+	
+	public static final EDKeyPair random() throws CryptoException
+	{
+		if (SKIP_SIGNING == false || SKIP_VERIFICATION == false)
+			throw new CryptoException("ED25519 signing and/or verification is not disabled, use a generated keypair!");
+		
+		final byte privkey[] = new byte[ED25519.PRIVATE_KEY_SIZE];
+		final byte pubkey[] = new byte[ED25519.PUBLIC_KEY_SIZE];
+		ThreadLocalRandom.current().nextBytes(privkey);
+		ThreadLocalRandom.current().nextBytes(pubkey);
+		return new EDKeyPair(privkey, pubkey);
+	}
 
 	private final EDPrivateKey privateKey;
 	private final EDPublicKey publicKey;
@@ -119,6 +133,19 @@ public final class EDKeyPair extends KeyPair<EDPrivateKey, EDPublicKey, EDSignat
 		}
 	}
 	
+	private EDKeyPair(byte[] privkey, byte[] pubkey) throws CryptoException 
+	{
+		try 
+		{
+			this.privateKey = EDPrivateKey.from(privkey);
+			this.publicKey = EDPublicKey.from(pubkey);
+		} 
+		catch (Exception ex) 
+		{
+			throw new CryptoException(ex);
+		}
+	}
+
 	public EDPrivateKey getPrivateKey() 
 	{
 		return this.privateKey;

--- a/core/src/main/java/org/radix/hyperscale/crypto/ed25519/EDSignature.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/ed25519/EDSignature.java
@@ -1,28 +1,31 @@
 package org.radix.hyperscale.crypto.ed25519;
 
+import java.util.Arrays;
 import java.util.Objects;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.radix.hyperscale.crypto.Signature;
 import org.radix.hyperscale.utils.Bytes;
-import org.radix.hyperscale.utils.Numbers;
 
 public final class EDSignature extends Signature
 {
-	public final static EDSignature NULL = new EDSignature(new byte[ED25519.SIGNATURE_SIZE]);
+	public final static EDSignature NULL = new EDSignature(new byte[ED25519.SIGNATURE_SIZE], 0);
 	
 	public static EDSignature from(byte[] bytes)
 	{
-		Objects.requireNonNull(bytes, "Bytes is null for EC point");
-		Numbers.isZero(bytes.length, "Bytes length is zero");
-		return new EDSignature(bytes);
+		return from(bytes, 0);
 	}
 	
+	public static EDSignature from(byte[] bytes, int offset)
+	{
+		return new EDSignature(bytes, offset);
+	}
+
 	private final byte[] bytes;
 
-	private EDSignature(byte[] bytes)
+	private EDSignature(byte[] bytes, int offset)
 	{
-		this.bytes = ArrayUtils.clone(bytes);
+		Objects.requireNonNull(bytes, "Signature bytes is null");
+		this.bytes = Arrays.copyOfRange(bytes, offset, bytes.length);
 	}
 
 	@Override

--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleAudit.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleAudit.java
@@ -1,0 +1,82 @@
+package org.radix.hyperscale.crypto.merkle;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.crypto.merkle.MerkleProof.Branch;
+import org.radix.hyperscale.serialization.DsonOutput;
+import org.radix.hyperscale.serialization.Serializable;
+import org.radix.hyperscale.serialization.SerializerId2;
+import org.radix.hyperscale.utils.Numbers;
+import org.radix.hyperscale.serialization.DsonOutput.Output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SerializerId2("merkle.audit")
+public final class MerkleAudit extends Serializable implements Iterable<MerkleProof>
+{
+	public static final MerkleAudit NULL = singleton(MerkleProof.from(Hash.ZERO, Branch.ROOT));
+
+	public static final MerkleAudit singleton(MerkleProof proof)
+	{
+		Objects.requireNonNull(proof, "Proof is null");
+		return new MerkleAudit(Collections.singletonList(proof));
+	}
+	
+	@JsonProperty("proofs")
+	@DsonOutput(Output.ALL)
+	private List<MerkleProof> proofs;
+	
+	private MerkleAudit()
+	{
+		// FOR SERIALIZER
+	}
+	
+	MerkleAudit(final List<MerkleProof> proofs)
+	{
+		Objects.requireNonNull(proofs, "Proofs is null");
+		Numbers.isZero(proofs.size(), "Proofs is empty");
+		
+		this.proofs = proofs;
+	}
+	
+	@Override
+	public Iterator<MerkleProof> iterator() 
+	{
+	    return new Iterator<MerkleProof>() 
+	    {
+	        private final Iterator<MerkleProof> delegate = proofs.iterator();
+	        
+	        @Override
+	        public boolean hasNext() 
+	        {
+	            return delegate.hasNext();
+	        }
+	        
+	        @Override
+	        public MerkleProof next() 
+	        {
+	            return delegate.next();
+	        }
+	        
+	        @Override
+	        public void remove() 
+	        {
+	            throw new UnsupportedOperationException("Cannot modify MerkleAudit");
+	        }
+	    };
+	}
+
+	public boolean isEmpty()
+	{
+		return this.proofs.isEmpty();
+	}
+
+	public int size()
+	{
+		return this.proofs.size();
+	}
+}

--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleNode.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleNode.java
@@ -1,6 +1,9 @@
-package org.radix.hyperscale.crypto;
+package org.radix.hyperscale.crypto.merkle;
 
 import java.security.InvalidParameterException;
+
+import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.crypto.Hashable;
 
 public class MerkleNode implements Hashable
 {

--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleProof.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleProof.java
@@ -1,6 +1,8 @@
-package org.radix.hyperscale.crypto;
+package org.radix.hyperscale.crypto.merkle;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.crypto.Hashable;
 
 public class MerkleProof implements Hashable
 {

--- a/core/src/main/java/org/radix/hyperscale/serialization/Serialization.java
+++ b/core/src/main/java/org/radix/hyperscale/serialization/Serialization.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.json.JSONObject;
 import org.radix.hyperscale.crypto.Hash;
 import org.radix.hyperscale.crypto.Identity;
-import org.radix.hyperscale.crypto.MerkleProof;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 import org.radix.hyperscale.ledger.ShardGroupID;
 import org.radix.hyperscale.ledger.ShardID;
 import org.radix.hyperscale.serialization.DsonOutput.Output;

--- a/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMapper.java
+++ b/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMapper.java
@@ -11,12 +11,12 @@ import java.util.function.Function;
 
 import org.radix.hyperscale.crypto.Hash;
 import org.radix.hyperscale.crypto.Identity;
-import org.radix.hyperscale.crypto.MerkleProof;
 import org.radix.hyperscale.crypto.Signature;
 import org.radix.hyperscale.crypto.bls12381.BLSSignature;
 import org.radix.hyperscale.crypto.ed25519.EDKeyPair;
 import org.radix.hyperscale.crypto.ed25519.EDPublicKey;
 import org.radix.hyperscale.crypto.ed25519.EDSignature;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 import org.radix.hyperscale.ledger.ShardGroupID;
 import org.radix.hyperscale.ledger.ShardID;
 import org.radix.hyperscale.ledger.StateAddress;
@@ -335,9 +335,9 @@ public class JacksonCborMapper extends ObjectMapper
 					throw new InvalidFormatException(p, "Expecting signature bytes but null or empty", bytes, handledType());
 				
 				if (bytes[0] == JacksonCodecConstants.EC_SIGNATURE_VALUE)
-					return EDSignature.from(Arrays.copyOfRange(bytes, 1, bytes.length));
+					return EDSignature.from(bytes, 1);
 				else if (bytes[0] == JacksonCodecConstants.BLS_SIGNATURE_VALUE)
-					return BLSSignature.from(Arrays.copyOfRange(bytes, 1, bytes.length));
+					return BLSSignature.from(bytes, 1);
 				else
 					throw new InvalidFormatException(p, "Unexpected prefix "+bytes[0], bytes, handledType());
 			}

--- a/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMerkleProofDeserializer.java
+++ b/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMerkleProofDeserializer.java
@@ -2,7 +2,7 @@ package org.radix.hyperscale.serialization.mapper;
 
 import java.io.IOException;
 
-import org.radix.hyperscale.crypto.MerkleProof;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMerkleProofSerializer.java
+++ b/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonCborMerkleProofSerializer.java
@@ -3,7 +3,7 @@ package org.radix.hyperscale.serialization.mapper;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.radix.hyperscale.crypto.MerkleProof;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonJsonMapper.java
+++ b/core/src/main/java/org/radix/hyperscale/serialization/mapper/JacksonJsonMapper.java
@@ -5,11 +5,11 @@ import java.util.ArrayList;
 
 import org.radix.hyperscale.crypto.Hash;
 import org.radix.hyperscale.crypto.Identity;
-import org.radix.hyperscale.crypto.MerkleProof;
 import org.radix.hyperscale.crypto.bls12381.BLSSignature;
 import org.radix.hyperscale.crypto.ed25519.EDKeyPair;
 import org.radix.hyperscale.crypto.ed25519.EDPublicKey;
 import org.radix.hyperscale.crypto.ed25519.EDSignature;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 import org.radix.hyperscale.ledger.ShardGroupID;
 import org.radix.hyperscale.ledger.ShardID;
 import org.radix.hyperscale.ledger.StateAddress;


### PR DESCRIPTION
A number of improvements, mainly minor, to ED25519, BLS381 and Blooms.

More significant improvements to Merkle audits, now carried by a dedicated type rather than a list of proofs.  Makes for easier management, parsing and processing.