### PR TITLE
Custom collections & object pools

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/collections/AbstractObjectPool.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AbstractObjectPool.java
@@ -1,0 +1,123 @@
+package org.radix.hyperscale.collections;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+abstract class AbstractObjectPool<T> extends ObjectPool<T>
+{
+    private final int capacity;
+    private final Supplier<T> supplier;
+    private final Predicate<T> recycler;
+    
+    private final AtomicLong allocated;
+    private final AtomicLong recycled;
+    private final AtomicLong discarded;
+    private final AtomicLong expired;
+    private final AtomicLong assigned;
+    private final AtomicLong released;
+
+    AbstractObjectPool(final String label, final int capacity, final Supplier<T> supplier, final Predicate<T> recycler)
+	{
+		super(label);
+		
+    	this.capacity = capacity;
+    	this.supplier = supplier;
+    	this.recycler = recycler;
+    	
+        this.allocated = new AtomicLong(0);
+        this.recycled = new AtomicLong(0);
+        this.discarded = new AtomicLong(0);
+        this.expired = new AtomicLong(0);
+        this.assigned = new AtomicLong(0);
+        this.released = new AtomicLong(0);
+	}
+    
+    final public int capacity()
+    {
+    	return this.capacity;
+    }
+    
+    final long incrementAllocated()
+    {
+    	return this.allocated.incrementAndGet();
+    }
+    
+    final long totalAllocated()
+    {
+    	return this.allocated.get();
+    }
+
+    final long incrementRecycled()
+    {
+    	return this.recycled.incrementAndGet();
+    }
+
+    final long totalRecycled()
+    {
+    	return this.recycled.get();
+    }
+
+    final long incrementDiscarded()
+    {
+    	return this.discarded.incrementAndGet();
+    }
+
+    final long totalDiscarded()
+    {
+    	return this.discarded.get();
+    }
+
+    final long incrementExpired()
+    {
+    	return this.expired.incrementAndGet();
+    }
+
+    final long totalExpired()
+    {
+    	return this.expired.get();
+    }
+
+    final long incrementAssigned()
+    {
+    	return this.assigned.incrementAndGet();
+    }
+
+    final long totalAssigned()
+    {
+    	return this.assigned.get();
+    }
+
+    final long incrementReleased()
+    {
+    	return this.released.incrementAndGet();
+    }
+
+    final long totalReleased()
+    {
+    	return this.released.get();
+    }
+
+    final T instantiate() 
+    {
+    	try
+    	{
+    		return this.supplier.get();
+    	}
+    	finally
+    	{
+    		incrementAllocated();
+    	}
+    }
+
+    final boolean recyclable(final T object)
+    {
+    	Objects.requireNonNull(object, "Object to recycle is null");
+    	
+    	if (this.recycler == null)
+    		return true;
+    	
+    	return this.recycler.test(object);
+    }
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/AdaptiveArrayList.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AdaptiveArrayList.java
@@ -1,0 +1,205 @@
+package org.radix.hyperscale.collections;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.RandomAccess;
+
+public class AdaptiveArrayList<E> extends AbstractList<E> implements RandomAccess, AdaptiveCollection<E>, java.io.Serializable
+{
+	private static final long serialVersionUID = -7000810147461243037L;
+	
+	private static final int DEFAULT_ARRAY_SIZE = 8;
+
+    private volatile Object[] elements;
+    private volatile int size;
+    private volatile boolean frozen;
+    private volatile boolean fixed;
+
+    public AdaptiveArrayList()
+    {
+    	this(DEFAULT_ARRAY_SIZE);
+    }
+    
+    public AdaptiveArrayList(int capacity)
+    {
+    	super();
+    	
+   		this.elements = new Object[capacity];
+    	this.size = 0;
+    	this.fixed = false;
+    	this.frozen = false;
+    }
+    
+    /**
+     * Constructs a list containing the elements of the specified
+     * collection, in the order they are returned by the collection's
+     * iterator.
+     *
+     * @param c the collection whose elements are to be placed into this list
+     * @throws NullPointerException if the specified collection is null
+     */
+    public AdaptiveArrayList(Collection<? extends E> c) 
+    {
+    	super();
+        
+        if (c instanceof AdaptiveArrayList adaptiveArrayList) 
+        {
+        	this.elements = new Object[adaptiveArrayList.size()];
+        	for (int i = 0 ; i < this.elements.length ; i++)
+        		this.elements[i] = adaptiveArrayList.get(i);
+        }
+        else if (c instanceof ArrayList arrayList) 
+        {
+        	this.elements = new Object[arrayList.size()];
+        	for (int i = 0 ; i < this.elements.length ; i++)
+        		this.elements[i] = arrayList.get(i);
+        }
+        else
+        	this.elements = c.toArray();
+        
+    	this.size = c.size();
+    	this.frozen = false;
+    	this.fixed = false;
+    }
+    
+    /**
+     * Constructs a list containing the elements of the specified array.  The array must
+     * not contain null values.
+     *
+     * @param array the array whose elements are to be placed into this list
+     * @throws NullPointerException if the specified collection is null
+     */
+    public AdaptiveArrayList(E ... array) 
+    {
+    	super();
+        
+       	this.elements = new Object[array.length];
+       	for (int i = 0 ; i < this.elements.length ; i++)
+       	{
+       		E element = array[i];
+       		if (element == null)
+       			throw new IllegalArgumentException("Array element "+i+" is null");
+       		
+       		this.elements[i] = array[i];
+       	}
+
+       	this.size = array.length;
+    	this.frozen = false;
+    	this.fixed = false;
+    }
+
+    @Override
+    public void clear()
+    {
+    	checkMutable();
+    	this.modCount++;
+    	Arrays.fill(this.elements, null);
+    	this.size = 0;
+    }
+
+    @Override
+	public int size()
+	{
+		return this.size;
+	}
+    
+	/**
+     * Appends the specified element to the end of this list.
+     *
+     * @param e element to be appended to this list
+     * @return {@code true} (as specified by {@link Collection#add})
+     */
+    public boolean add(E e) 
+    {
+    	checkMutable();
+    	this.modCount++;
+        add(e, this.size);
+        return true;
+    }
+    
+    private void add(E e, int s) 
+    {
+        if (s == this.elements.length)
+        	grow();
+    
+        this.elements[s] = e;
+        this.size = s + 1;
+    }
+    
+    /**
+     * Returns the element at the specified position in this list.
+     *
+     * @param  index index of the element to return
+     * @return the element at the specified position in this list
+     * @throws IndexOutOfBoundsException {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+	public E get(int index) 
+    {
+        Objects.checkIndex(index, size);
+        return (E) this.elements[index];
+    }
+    
+    /**
+     * Replaces the element at the specified position in this list with
+     * the specified element.
+     *
+     * @param index index of the element to replace
+     * @param element element to be stored at the specified position
+     * @return the element previously at the specified position
+     * @throws IndexOutOfBoundsException {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+	public E set(int index, E element) 
+    {
+        Objects.checkIndex(index, size);
+    	checkMutable();
+        
+        E oldValue = (E) this.elements[index];
+        this.elements[index] = element;
+        return oldValue;
+    }
+
+    /**
+     * Increases the capacity to ensure that it can hold at least the
+     * number of elements specified by the minimum capacity argument.
+     *
+     * @throws OutOfMemoryError if minCapacity is less than zero
+     */
+    private void grow() 
+    {
+    	checkGrowable();
+   		Object[] newElements = Arrays.copyOf(this.elements, this.elements.length * 2);
+   		this.elements = newElements;
+    		
+    }
+
+	@Override
+	public AdaptiveArrayList<E> freeze()
+	{
+		this.frozen = true;
+		return this;
+	}
+
+	@Override
+	public boolean isFrozen()
+	{
+		return this.frozen;
+	}
+	
+	@Override
+	public AdaptiveArrayList<E> fixed()
+	{
+		this.fixed = true;
+		return this;
+	}
+
+	@Override
+	public boolean isFixed()
+	{
+		return this.fixed;
+	}
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/AdaptiveCollection.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AdaptiveCollection.java
@@ -1,0 +1,96 @@
+package org.radix.hyperscale.collections;
+
+import java.util.Collection;
+
+/**
+ * A collection that can transition from mutable to immutable state, unsynchronised to synchronised, and 
+ * a number of other useful properties for improved collection utility.
+ */
+public interface AdaptiveCollection<E> extends Collection<E> 
+{
+    /**
+     * Freezes this collection, making it immutable.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this collection for method chaining
+     * @throws IllegalStateException if already frozen (optional)
+     */
+	default AdaptiveCollection<E> freeze()
+	{
+		throw new UnsupportedOperationException("Freezing is not supported");
+	}
+    
+    /**
+     * @return true if this collection has been frozen and is immutable
+     */
+    default boolean isFrozen()
+	{
+    	return false;
+	}
+    
+    /**
+     * Fixes the capacity of this collection.  Collections which have 
+     * been fixed will throw an exception rather than growing to accommodate 
+     * new items.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this collection for method chaining
+     * @throws IllegalStateException if already frozen (optional)
+     */
+	default AdaptiveCollection<E> fixed()
+	{
+		throw new UnsupportedOperationException("Capacity fixing is not supported");
+	}
+    
+    /**
+     * @return true if this collection has a fixed capacity
+     */
+    default boolean isFixed()
+	{
+    	return false;
+	}
+
+    /**
+     * Synchronises this collection, making all future accesses synchronized.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this collection for method chaining
+     * @throws IllegalStateException if already synchronized (optional)
+     */
+	default AdaptiveCollection<E> sync()
+	{
+		throw new UnsupportedOperationException("Synchronization is not supported");
+	}
+    
+    /**
+     * @return true if this collection has been synchronized
+     */
+    default boolean isSync()
+	{
+    	return false;
+	}
+    
+    /**
+     * Default implementation for checking if mutations are allowed.
+     * Implementations should call this before any mutating operation.
+     * 
+     * @throws UnsupportedOperationException if the collection is frozen
+     */
+    default void checkMutable() 
+    {
+        if (isFrozen())
+            throw new UnsupportedOperationException("Collection is frozen and cannot be modified");
+    }
+    
+    /**
+     * Default implementation for checking if collection growth is allowed.
+     * Implementations should call this before any growth operation.
+     * 
+     * @throws UnsupportedOperationException if the collection is fixed
+     */
+    default void checkGrowable() 
+    {
+        if (isFixed())
+            throw new UnsupportedOperationException("Collection is fixed and cannot be grown");
+    }
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/AdaptiveHashSet.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AdaptiveHashSet.java
@@ -1,0 +1,498 @@
+package org.radix.hyperscale.collections;
+
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class AdaptiveHashSet<E> extends AbstractSet<E> implements AdaptiveCollection<E>, java.io.Serializable
+{
+	private static final long serialVersionUID = 7449746608855880597L;
+
+	private static final int MINIMUM_SET_SIZE = 2;
+	private static final int DEFAULT_SET_SIZE = 8;
+
+    private volatile Object[] elements;
+    private volatile int size;
+    private volatile boolean frozen;
+    private volatile boolean fixed;
+    
+    protected volatile transient int modCount = 0;
+
+    public AdaptiveHashSet()
+    {
+    	this(DEFAULT_SET_SIZE);
+    }
+    
+    public AdaptiveHashSet(int capacity)
+    {
+    	super();
+    	
+   		this.elements = new Object[Math.max(capacity, MINIMUM_SET_SIZE)];
+    	this.size = 0;
+    	this.fixed = false;
+    	this.frozen = false;
+    }
+    
+    /**
+     * Constructs a list containing the elements of the specified
+     * collection, in the order they are returned by the collection's
+     * iterator.
+     *
+     * @param c the collection whose elements are to be placed into this list
+     * @throws NullPointerException if the specified collection is null
+     */
+    public AdaptiveHashSet(Collection<? extends E> c) 
+    {
+    	super();
+        
+        if (c instanceof AdaptiveArrayList adaptiveArrayList) 
+        {
+        	this.elements = new Object[Math.max(adaptiveArrayList.size(), MINIMUM_SET_SIZE)];
+        	for (int i = 0 ; i < this.elements.length ; i++)
+           		add((E) adaptiveArrayList.get(i));
+        }
+        else if (c instanceof ArrayList arrayList) 
+        {
+        	this.elements = new Object[Math.max(arrayList.size(), MINIMUM_SET_SIZE)];
+        	for (int i = 0 ; i < this.elements.length ; i++)
+        		add((E) arrayList.get(i));
+        }
+        else
+        {
+        	final Object[] array = c.toArray();
+        	this.elements = new Object[Math.max(array.length, MINIMUM_SET_SIZE)];
+        	for (int i = 0 ; i < array.length ; i++)
+        		add((E) array[i]);
+        }
+        
+    	this.size = c.size();
+    	this.frozen = false;
+    	this.fixed = false;
+    }
+    
+    /**
+     * Constructs a list containing the elements of the specified array.  The array must
+     * not contain null values.
+     *
+     * @param array the array whose elements are to be placed into this list
+     * @throws NullPointerException if the specified collection is null
+     */
+    public AdaptiveHashSet(E ... array) 
+    {
+    	super();
+        
+       	this.elements = new Object[Math.max(array.length, MINIMUM_SET_SIZE)];
+       	for (int i = 0 ; i < this.elements.length ; i++)
+       	{
+       		E element = array[i];
+       		if (element == null)
+       			throw new IllegalArgumentException("Element "+i+" is null");
+       		
+       		add(array[i]);
+       	}
+
+       	this.size = array.length;
+    	this.frozen = false;
+    	this.fixed = false;
+    }
+
+    @Override
+    public void clear()
+    {
+    	checkMutable();
+    	this.modCount++;
+    	Arrays.fill(this.elements, null);
+    	this.size = 0;
+    }
+
+    @Override
+	public int size()
+	{
+		return this.size;
+	}
+    
+	/**
+     * Appends the specified element to the end of this list.
+     *
+     * @param e element to be appended to this list
+     * @return {@code true} (as specified by {@link Collection#add})
+     */
+    public boolean add(E element) 
+    {
+        return add(element, this.size);
+    }
+    
+    private boolean add(E element, int s) 
+    {
+    	checkMutable();
+        if (s == this.elements.length)
+        	grow();
+        
+        final int slot = slot(element.hashCode());
+        if (mergeItem(element, slot) == false)
+        	return false;
+        
+       	this.modCount++;
+       	this.size = s + 1;
+        return true;
+    }
+    
+	@Override
+	public boolean contains(Object object)
+	{
+        final int slot = slot(object.hashCode());
+        return containsItem(object, slot);
+	}
+
+	@Override
+	public boolean remove(Object object)
+	{
+    	checkMutable();
+        final int slot = slot(object.hashCode());
+        final E removed = removeItem(object, slot);
+        if (removed != null) 
+        {
+        	if (isSlotVoid(slot))
+        		this.elements[slot] = null;
+        	
+        	this.size--;
+            this.modCount++;
+            return true;
+		}
+        
+        return false;
+	}
+
+	@Override
+	public Iterator<E> iterator()
+	{
+		return new Itr();
+	}
+	
+	@Override
+	public Object[] toArray() 
+	{
+	    final Object[] result = new Object[this.size];
+	    int index = 0;
+
+	    for (final Object entry : this.elements) 
+	    {
+	        if (entry == null) 
+	        	continue;
+
+	        if (entry instanceof Object[] bucket) 
+	        {
+	            for (Object obj : bucket) 
+	            {
+	                if (obj != null)
+	                    result[index++] = obj;
+	            }
+	        } 
+	        else
+	            result[index++] = entry;
+	    }
+
+	    return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T[] toArray(T[] a) 
+	{
+	    int actualSize = this.size;
+	    final T[] result = (a.length >= actualSize) ? a : (T[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), actualSize);
+
+	    int index = 0;
+	    for (final Object entry : this.elements) 
+	    {
+	        if (entry == null) 
+	        	continue;
+
+	        if (entry instanceof Object[] bucket) 
+	        {
+	            for (Object obj : bucket) 
+	            {
+	                if (obj != null)
+	                    result[index++] = (T) obj;
+	            }
+	        } 
+	        else 
+	            result[index++] = (T) entry;
+	    }
+
+	    if (result.length > actualSize)
+	        result[actualSize] = null;
+
+	    return result;
+	}
+
+    /**
+     * Increases the capacity to ensure that it can hold at least the
+     * number of elements specified by the minimum capacity argument.
+     *
+     * @throws OutOfMemoryError if minCapacity is less than zero
+     */
+    private void grow() 
+    {
+    	checkGrowable();
+    	Object[] oldElements = this.elements;
+   		this.elements = new Object[this.elements.length * 2];
+   		for (int i = 0 ; i < oldElements.length ; i++)
+   		{
+   			final Object entry = oldElements[i];
+   			if (entry == null)
+   				continue;
+   			
+   			if (entry instanceof Object[] bucket)
+   			{
+   				for (int c = 0 ; c < bucket.length ; c++)
+   				{
+   					if (bucket[c] == null)
+   						continue;
+   					
+   					final int slot = slot(bucket[c].hashCode());
+   					mergeItem((E)bucket[c], slot);
+   				}
+   			}
+   			else
+   			{
+   				final int slot = slot(entry.hashCode());
+				mergeItem((E)entry, slot);
+   			}
+   		}
+    }
+    
+    private int slot(final int hash) 
+    {
+        return Math.abs(hash % this.elements.length);
+    }
+    
+    private boolean isSlotVoid(int slot)
+    {
+    	if (this.elements[slot] == null)
+    		return true;
+    	
+    	final Object entry = this.elements[slot];
+    	if (entry instanceof Object[] bucket)
+    	{
+    		for (int i = 0 ; i < bucket.length ; i++)
+    		{
+    			if (bucket[i] != null)
+    				return false;
+    		}
+    	}
+    	
+    	return true;
+    }
+
+    private boolean containsItem(final Object element, final int slot) 
+    {
+    	final Object entry = this.elements[slot];
+        if (entry instanceof Object[] bucket) 
+        {
+        	for (int i = 0 ; i < bucket.length ; i++)
+            {
+        		if (bucket[i] == null)
+        			continue;
+        		
+                if (element.equals(bucket[i])) 
+                  	return true;
+            }
+        }
+        
+        return element.equals(entry);
+    }
+
+    private E removeItem(final Object element, final int slot) 
+    {
+    	final Object entry = this.elements[slot];
+        if (entry instanceof Object[] bucket) 
+        {
+            for (int i = 0; i < bucket.length; i++) 
+            {
+            	if (bucket[i] == null)
+            		continue;
+            	
+            	if (element.equals(bucket[i])) 
+                {
+            		bucket[i] = null;
+                    return (E) element;
+                }
+            }
+        }
+        else if (element.equals(entry))
+        {
+        	this.elements[slot] = null;
+        	return (E) element;
+        }
+        
+        return null;
+    }
+
+    private boolean mergeItem(final E element, final int slot) 
+    {
+    	final Object entry = this.elements[slot];
+        if (entry instanceof Object[] bucket) 
+        {
+            for (int i = 0; i < bucket.length; i++) 
+            {
+            	if (bucket[i] == null)
+            		continue;
+            	
+                if (element.equals(bucket[i])) 
+                    return false;
+            }
+            
+            for (int i = 0; i < bucket.length; i++) 
+            {
+                if (bucket[i] == null) 
+                {
+                    bucket[i] = element;
+                    return true;
+                }
+            }
+            
+            final Object[] expanded = Arrays.copyOf(bucket, bucket.length * 2);
+            expanded[bucket.length] = element;
+            this.elements[slot] = expanded;
+            return true;
+        }
+        else if (element.equals(entry) == false)
+        {
+        	if (entry == null)
+            	this.elements[slot] = element;
+        	else
+        		this.elements[slot] = new Object[]{entry, element};
+        	
+            return true;
+        }
+        
+        return false;
+    }
+    
+	@Override
+	public AdaptiveHashSet<E> freeze()
+	{
+		this.frozen = true;
+		return this;
+	}
+
+	@Override
+	public boolean isFrozen()
+	{
+		return this.frozen;
+	}
+	
+	@Override
+	public AdaptiveHashSet<E> fixed()
+	{
+		this.fixed = true;
+		return this;
+	}
+
+	@Override
+	public boolean isFixed()
+	{
+		return this.fixed;
+	}
+	
+    private class Itr implements Iterator<E> 
+    {
+        private final int expectedModCount;
+        private int index = 0;
+        private int bucketIndex = -1;
+        private E nextElement = null;
+        private E lastReturned = null;
+
+        Itr()
+        {
+        	this.expectedModCount = AdaptiveHashSet.this.modCount;
+            advance();
+        }
+
+        private void checkForConcurrentModification() 
+        {
+            if (AdaptiveHashSet.this.modCount != this.expectedModCount)
+                throw new java.util.ConcurrentModificationException();
+        }
+
+        private void advance() 
+        {
+            this.nextElement = null;
+            while (this.index < AdaptiveHashSet.this.elements.length) 
+            {
+                Object entry = AdaptiveHashSet.this.elements[this.index];
+
+                if (entry == null) 
+                {
+                	this.index++;
+                	this.bucketIndex = -1;
+                    continue;
+                }
+
+                if (entry instanceof Object[] bucket) 
+                {
+                	this.bucketIndex++;
+                    while (this.bucketIndex < bucket.length) 
+                    {
+                        Object candidate = bucket[this.bucketIndex];
+                        if (candidate != null) 
+                        {
+                        	this.nextElement = (E) candidate;
+                            return;
+                        }
+                        this.bucketIndex++;
+                    }
+                    this.index++;
+                    this.bucketIndex = -1;
+                } 
+                else 
+                {
+                	this.nextElement = (E) entry;
+                	this.index++;
+                	this.bucketIndex = -1;
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() 
+        {
+            return this.nextElement != null;
+        }
+
+        @Override
+        public E next() 
+        {
+            checkForConcurrentModification();
+            if (this.nextElement == null)
+                throw new java.util.NoSuchElementException();
+
+            this.lastReturned = this.nextElement;
+            advance();
+            return this.lastReturned;
+        }
+
+        @Override
+        public void remove() 
+        {
+            checkForConcurrentModification();
+            if (this.lastReturned == null)
+                throw new IllegalStateException();
+            
+            final int slot = slot(this.lastReturned.hashCode());
+            final E removed = removeItem(this.lastReturned, slot);
+            if (removed != null) 
+            {
+            	if (isSlotVoid(slot))
+            		AdaptiveHashSet.this.elements[slot] = null;
+            	
+            	AdaptiveHashSet.this.size--;
+            }
+            this.lastReturned = null;
+        }
+    }
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/AdaptiveMap.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AdaptiveMap.java
@@ -1,0 +1,67 @@
+package org.radix.hyperscale.collections;
+
+import java.util.Map;
+
+/**
+ * A map that can transition from mutable to immutable state, unsynchronised to synchronised, and 
+ * a number of other useful properties for improved collection utility.
+ */
+public interface AdaptiveMap<K, E> extends Map<K, E> 
+{
+    /**
+     * Freezes this map, making it immutable.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this map for method chaining
+     * @throws IllegalStateException if already frozen (optional)
+     */
+	AdaptiveMap<K, E> freeze();
+    
+    /**
+     * @return true if this map has been frozen and is immutable
+     */
+    boolean isFrozen();
+    
+    /**
+     * Fixes the capacity of this map.  Maps which have 
+     * been fixed will throw an exception rather than growing to accommodate 
+     * new items.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this map for method chaining
+     * @throws IllegalStateException if already frozen (optional)
+     */
+    AdaptiveMap<K, E> fixed();
+    
+    /**
+     * @return true if this map has a fixed capacity
+     */
+    boolean isFixed();
+
+    /**
+     * Synchronises this map, making all future accesses synchronised.
+     * This is a one-way operation that cannot be reversed.
+     * 
+     * @return this map for method chaining
+     * @throws IllegalStateException if already synchronised (optional)
+     */
+    AdaptiveMap<K, E> synchronised();
+    
+    /**
+     * @return true if this collection has been synchronised
+     */
+    boolean isSynchronised();
+
+    
+    /**
+     * Default implementation for checking if mutations are allowed.
+     * Implementations should call this before any mutating operation.
+     * 
+     * @throws UnsupportedOperationException if the map is frozen
+     */
+    default void checkMutable() 
+    {
+        if (isFrozen())
+            throw new UnsupportedOperationException("Map is frozen and cannot be modified");
+    }
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/AdaptiveMap.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/AdaptiveMap.java
@@ -64,4 +64,16 @@ public interface AdaptiveMap<K, E> extends Map<K, E>
         if (isFrozen())
             throw new UnsupportedOperationException("Map is frozen and cannot be modified");
     }
+    
+    /**
+     * Default implementation for checking if collection growth is allowed.
+     * Implementations should call this before any growth operation.
+     * 
+     * @throws UnsupportedOperationException if the collection is fixed
+     */
+    default void checkGrowable() 
+    {
+        if (isFixed())
+            throw new UnsupportedOperationException("Collection is fixed and cannot be grown");
+    }
 }

--- a/core/src/main/java/org/radix/hyperscale/collections/ObjectPool.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/ObjectPool.java
@@ -1,0 +1,61 @@
+package org.radix.hyperscale.collections;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import org.radix.hyperscale.utils.Numbers;
+
+public abstract class ObjectPool<T>
+{
+    final static List<WeakReference<ObjectPool<?>>> instances = Collections.synchronizedList(new LinkedList<WeakReference<ObjectPool<?>>>());
+    public final static Iterator<WeakReference<ObjectPool<?>>> instances()
+    {
+    	synchronized(instances)
+    	{
+    		final List<WeakReference<ObjectPool<?>>> live = new ArrayList<WeakReference<ObjectPool<?>>>(instances.size());
+    		final Iterator<WeakReference<ObjectPool<?>>> instanceIterator = instances.iterator();
+    		while(instanceIterator.hasNext())
+    		{
+    			final WeakReference<ObjectPool<?>> instanceRef = instanceIterator.next();
+    			final ObjectPool<?> instance = instanceRef.get();
+    			if (instance == null)
+    			{
+    				instanceIterator.remove();
+    				continue;
+    			}
+    			
+    			live.add(instanceRef);
+    		}
+    		
+    		return live.iterator();
+    	}
+    }
+    
+    static enum PoolReturnStatus 
+    {
+    	UNKNOWN, RETURNED, STALE, DISCARDED, FULL
+    }
+    
+    private final String label;
+
+    ObjectPool(final String label)
+    {
+    	Objects.requireNonNull(label, "Label is null");
+    	Numbers.inRange(label.length(), 3, 32, "Pool label is invalid length");
+    	this.label = label;
+    	
+    	ObjectPool.instances.add(new WeakReference<ObjectPool<?>>(this));
+    }
+    
+    public String getLabel()
+    {
+    	return this.label;
+    }
+
+    public abstract void clear();
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/PoolBorrower.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/PoolBorrower.java
@@ -1,0 +1,6 @@
+package org.radix.hyperscale.collections;
+
+public interface PoolBorrower
+{
+	public void release();
+}

--- a/core/src/main/java/org/radix/hyperscale/collections/SimpleObjectPool.java
+++ b/core/src/main/java/org/radix/hyperscale/collections/SimpleObjectPool.java
@@ -1,0 +1,105 @@
+package org.radix.hyperscale.collections;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public final class SimpleObjectPool<T> extends AbstractObjectPool<T>
+{
+    private final Deque<T> pool;
+    private final AtomicInteger poolCount;
+
+    public SimpleObjectPool(final String label, final int capacity, final Supplier<T> supplier, final Predicate<T> recycler) 
+    {
+    	super(label, capacity, supplier, recycler);
+
+        this.pool = new ArrayDeque<T>(capacity);
+        this.poolCount = new AtomicInteger(0);
+    }
+	    
+	/**
+     * Acquire an object from the pool
+     * 
+     * @return an object of type T
+     */
+    public T acquire() 
+    {
+        T object;
+        synchronized(this.pool)
+        {
+        	object = this.pool.poll();
+        }
+        
+        if (object != null) 
+        {
+        	this.poolCount.decrementAndGet();
+        	incrementRecycled();
+        }
+        else
+	        object = instantiate();
+
+        incrementAssigned();
+        return object;
+    }
+    
+    public PoolReturnStatus release(final T object)
+    {
+    	final PoolReturnStatus status = revoke(object);
+    	switch(status)
+    	{
+    	case PoolReturnStatus.DISCARDED:
+    	case PoolReturnStatus.FULL:
+    		incrementDiscarded();
+    	case PoolReturnStatus.RETURNED:
+    		incrementReleased();
+    		break;
+    	default:
+    		break;
+    	}
+       	return status;
+    }
+
+    private PoolReturnStatus revoke(final T object) 
+    {
+        final int bcCheck = this.poolCount.incrementAndGet();
+        final boolean recycle = recyclable(object);
+        
+        if (bcCheck <= capacity() && recycle == true) 
+        {
+            synchronized(this.pool)
+            {
+            	this.pool.offer(object);
+            }
+            return PoolReturnStatus.RETURNED;
+        } 
+        else
+        {
+            this.poolCount.decrementAndGet();
+
+            if (recycle == false)
+            	return PoolReturnStatus.DISCARDED;
+            else
+            	return PoolReturnStatus.FULL;
+        }
+    }
+    
+    /**
+     * Clear all buffers from the pool
+     */
+    public void clear() 
+    {
+        this.pool.clear();
+        this.poolCount.set(0);
+    }
+    
+    @Override
+    public String toString() 
+    {
+    	return String.format("ObjectPool{%s-%d, pooled=%d, allocated=%d, assigned=%d, released=%d, recycled=%d, discarded=%d, expired=%d}", 
+    							getLabel(), hashCode(), this.poolCount.get(), 
+    							totalAllocated(), totalAssigned(), totalReleased(), 
+    							totalRecycled(), totalDiscarded(), totalExpired());
+    }
+}


### PR DESCRIPTION
Stage 1 of implementing a suite of custom collections and object pools

Standard Java collections are very heavy with regard to GC pressure, which in turn causes "stop the world" GC events under heavy load.  3rd party libraries are generally over-engineered for requirements here, or move GC pressure elsewhere in their operation.

Similar situation with object pools, 3rd party solutions are over-engineered, or are part of a much larger library without an easy separation.