### PR TITLE
Merkle updates

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleAudit.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleAudit.java
@@ -1,10 +1,12 @@
 package org.radix.hyperscale.crypto.merkle;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import org.radix.hyperscale.collections.AdaptiveArrayList;
+import org.radix.hyperscale.collections.AdaptiveCollection;
 import org.radix.hyperscale.crypto.Hash;
 import org.radix.hyperscale.crypto.merkle.MerkleProof.Branch;
 import org.radix.hyperscale.serialization.DsonOutput;
@@ -23,7 +25,9 @@ public final class MerkleAudit extends Serializable implements Iterable<MerklePr
 	public static final MerkleAudit singleton(MerkleProof proof)
 	{
 		Objects.requireNonNull(proof, "Proof is null");
-		return new MerkleAudit(Collections.singletonList(proof));
+		final AdaptiveArrayList<MerkleProof> frozenSingleton = new AdaptiveArrayList<MerkleProof>(1);
+		frozenSingleton.add(proof);
+		return new MerkleAudit(frozenSingleton.freeze());
 	}
 	
 	@JsonProperty("proofs")
@@ -40,7 +44,10 @@ public final class MerkleAudit extends Serializable implements Iterable<MerklePr
 		Objects.requireNonNull(proofs, "Proofs is null");
 		Numbers.isZero(proofs.size(), "Proofs is empty");
 		
-		this.proofs = proofs;
+		if (proofs instanceof AdaptiveCollection adaptiveCollection && adaptiveCollection.isFrozen())
+			this.proofs = proofs;
+		else
+			this.proofs = new ArrayList<>(proofs);
 	}
 	
 	@Override

--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleProof.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleProof.java
@@ -48,7 +48,13 @@ public class MerkleProof implements Hashable
     
 	private MerkleProof(byte[] bytes, int offset)
 	{
-		this.direction = Branch.values()[bytes[offset]];
+		if (bytes[offset] == 0)
+			this.direction = Branch.LEFT;
+		else if (bytes[offset] == 1)
+			this.direction = Branch.RIGHT;
+		else
+			this.direction = Branch.ROOT;
+
 		this.hash = Hash.from(bytes, offset+1);
 	}
 

--- a/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleTree.java
+++ b/core/src/main/java/org/radix/hyperscale/crypto/merkle/MerkleTree.java
@@ -8,7 +8,9 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
 import org.eclipse.collections.impl.factory.primitive.LongObjectMaps;
+import org.radix.hyperscale.collections.AdaptiveArrayList;
 import org.radix.hyperscale.crypto.Hash;
+import org.radix.hyperscale.utils.MathUtils;
 
 public class MerkleTree
 {
@@ -128,7 +130,7 @@ public class MerkleTree
     			this.proofs = LongObjectMaps.mutable.<MerkleProof>ofInitialCapacity(this.leaves.size()*2).asSynchronized();
     	}
     	
-        final List<MerkleProof> auditTrail = new ArrayList<>();
+        final AdaptiveArrayList<MerkleProof> auditTrail = new AdaptiveArrayList<>(MathUtils.log2(this.leaves.size()));
         final MerkleNode leafNode = findLeaf(leafHash);
         if (leafNode != null) 
         {
@@ -139,7 +141,7 @@ public class MerkleTree
             buildAuditTrail(auditTrail, parent, leafNode);
         }
 
-        return new MerkleAudit(auditTrail);
+        return new MerkleAudit(auditTrail.freeze());
     }
 
     public static boolean verifyAudit(Hash rootHash, Hash leafHash, MerkleAudit auditTrail) 

--- a/core/src/main/java/org/radix/hyperscale/ledger/StateVote.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/StateVote.java
@@ -7,10 +7,11 @@ import java.util.List;
 import java.util.Objects;
 
 import org.radix.hyperscale.crypto.Hash;
-import org.radix.hyperscale.crypto.MerkleProof;
 import org.radix.hyperscale.crypto.bls12381.BLSKeyPair;
 import org.radix.hyperscale.crypto.bls12381.BLSPublicKey;
 import org.radix.hyperscale.crypto.bls12381.BLSSignature;
+import org.radix.hyperscale.crypto.merkle.MerkleAudit;
+import org.radix.hyperscale.crypto.merkle.MerkleProof;
 import org.radix.hyperscale.utils.Numbers;
 
 public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature>
@@ -47,7 +48,7 @@ public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature
 	private final Hash block;
 	private final Hash execution;
 	private final Hash voteMerkle;
-	private final List<MerkleProof> voteAudit;
+	private final MerkleAudit voteAudit;
 	
 	StateVote(final StateAddress address, final Hash atom, final Hash block, final Hash execution, final BLSPublicKey owner, final long weight)
 	{
@@ -58,10 +59,10 @@ public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature
 		this.execution = execution;
 		this.address = address;
 		this.voteMerkle = Hash.ZERO;
-		this.voteAudit = Collections.emptyList();
+		this.voteAudit = MerkleAudit.NULL;
 	}
 
-	StateVote(final StateAddress address, final Hash atom, final Hash block, final Hash execution, final Hash voteMerkle, final List<MerkleProof> voteAudit, final BLSPublicKey owner, final BLSSignature signature, final long weight)
+	StateVote(final StateAddress address, final Hash atom, final Hash block, final Hash execution, final Hash voteMerkle, final MerkleAudit voteAudit, final BLSPublicKey owner, final BLSSignature signature, final long weight)
 	{
 		super(convertToHash(address, atom, block, execution), execution.equals(Hash.ZERO) == false ? CommitDecision.ACCEPT : CommitDecision.REJECT, owner, signature, weight);
 		Objects.requireNonNull(voteMerkle, "Vote merkle is null");
@@ -75,10 +76,10 @@ public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature
 		this.execution = execution;
 		this.address = address;
 		this.voteMerkle = voteMerkle;
-		this.voteAudit = new ArrayList<MerkleProof>(voteAudit);
+		this.voteAudit = voteAudit;
 	}
 	
-	StateVote(final Hash object, final StateAddress address, final Hash atom, final Hash block, final Hash execution, final Hash voteMerkle, final List<MerkleProof> voteAudit, final BLSPublicKey owner, final BLSSignature signature, final long weight)
+	StateVote(final Hash object, final StateAddress address, final Hash atom, final Hash block, final Hash execution, final Hash voteMerkle, final MerkleAudit voteAudit, final BLSPublicKey owner, final BLSSignature signature, final long weight)
 	{
 		super(object, execution.equals(Hash.ZERO) == false ? CommitDecision.ACCEPT : CommitDecision.REJECT, owner, signature, weight);
 		
@@ -93,7 +94,7 @@ public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature
 		this.execution = execution;
 		this.address = address;
 		this.voteMerkle = voteMerkle;
-		this.voteAudit = new ArrayList<MerkleProof>(voteAudit);
+		this.voteAudit = voteAudit;
 	}
 
 	@Override
@@ -175,9 +176,9 @@ public final class StateVote extends Vote<BLSKeyPair, BLSPublicKey, BLSSignature
 		return this.voteMerkle;
 	}
 	
-	public List<MerkleProof> getVoteAudit()
+	public MerkleAudit getVoteAudit()
 	{
-		return Collections.unmodifiableList(this.voteAudit);
+		return this.voteAudit;
 	}
 	
 	// TODO put back to final

--- a/core/src/main/java/org/radix/hyperscale/ledger/primitives/StateCertificate.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/primitives/StateCertificate.java
@@ -2,18 +2,15 @@ package org.radix.hyperscale.ledger.primitives;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 import org.radix.hyperscale.collections.Bloom;
 import org.radix.hyperscale.crypto.CryptoException;
 import org.radix.hyperscale.crypto.Hash;
-import org.radix.hyperscale.crypto.MerkleProof;
 import org.radix.hyperscale.crypto.VoteCertificate;
 import org.radix.hyperscale.crypto.bls12381.BLSPublicKey;
 import org.radix.hyperscale.crypto.bls12381.BLSSignature;
+import org.radix.hyperscale.crypto.merkle.MerkleAudit;
 import org.radix.hyperscale.ledger.Block;
 import org.radix.hyperscale.ledger.CommitDecision;
 import org.radix.hyperscale.ledger.StateAddress;
@@ -57,7 +54,7 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 	@JsonProperty("block_audit")
 //	@DsonOutput(value = {Output.API, Output.WIRE, Output.PERSIST})
 	@DsonOutput(Output.NONE)
-	private List<MerkleProof> blockAudit;
+	private MerkleAudit blockAudit;
 	
 	// Batched StateVote merkle and audit
 	@JsonProperty("vote_merkle")
@@ -68,7 +65,7 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 	@JsonProperty("vote_audit")
 //	@DsonOutput(value = {Output.API, Output.WIRE, Output.PERSIST})
 	@DsonOutput(Output.NONE)
-	private List<MerkleProof> voteAudit;
+	private MerkleAudit voteAudit;
 
 	@SuppressWarnings("unused")
 	private StateCertificate()
@@ -79,7 +76,7 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 	}
 
 	public StateCertificate(final Hash atom, final Hash block, final SubstateTransitions states, final Hash execution, 
-							final Hash blockMerkle, final List<MerkleProof> blockAudit, final Hash voteMerkle, final List<MerkleProof> voteAudit, 
+							final Hash blockMerkle, final MerkleAudit blockAudit, final Hash voteMerkle, final MerkleAudit voteAudit, 
 							final Bloom signers, final BLSPublicKey key, final BLSSignature signature)
 	{
 		super(Objects.requireNonNull(execution, "Execution is null").equals(Hash.ZERO) == false ? CommitDecision.ACCEPT : CommitDecision.REJECT, signers, key, signature);
@@ -107,9 +104,9 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 		this.states = states;
 		this.execution = execution;
 		this.blockMerkle = blockMerkle;
-		this.blockAudit = new ArrayList<MerkleProof>(blockAudit);
+		this.blockAudit = blockAudit;
 		this.voteMerkle = voteMerkle;
-		this.voteAudit = new ArrayList<MerkleProof>(voteAudit);
+		this.voteAudit = voteAudit;
 	}
 
 	public Hash getBlock()
@@ -154,9 +151,9 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 		return this.blockMerkle;
 	}
 	
-	public List<MerkleProof> getBlockAudit()
+	public MerkleAudit getBlockAudit()
 	{
-		return Collections.unmodifiableList(this.blockAudit);
+		return this.blockAudit;
 	}
 
 	public Hash getVoteMerkle()
@@ -164,9 +161,9 @@ public final class StateCertificate extends VoteCertificate implements StateOutp
 		return this.voteMerkle;
 	}
 	
-	public List<MerkleProof> getVoteAudit()
+	public MerkleAudit getVoteAudit()
 	{
-		return Collections.unmodifiableList(this.voteAudit);
+		return this.voteAudit;
 	}
 
 	@Override


### PR DESCRIPTION
Simple update aligning leftover dependents of Merkles to utilize the newer MerkleAudit class rather than a list of MerkleProofs.

More efficient and easier to read / maintain.