### PR TITLE
Custom executor refactor

### DIFF
--- a/core/src/main/java/org/radix/hyperscale/database/SystemMetaData.java
+++ b/core/src/main/java/org/radix/hyperscale/database/SystemMetaData.java
@@ -16,7 +16,6 @@ import org.radix.hyperscale.exceptions.ServiceException;
 import org.radix.hyperscale.exceptions.StartupException;
 import org.radix.hyperscale.exceptions.TerminationException;
 import org.radix.hyperscale.executors.Executor;
-import org.radix.hyperscale.executors.ScheduledExecutable;
 import org.radix.hyperscale.logging.Logger;
 import org.radix.hyperscale.logging.Logging;
 import org.radix.hyperscale.utils.Bytes;
@@ -69,10 +68,10 @@ public final class SystemMetaData extends DatabaseStore implements Service
 			throw new RuntimeException(ex);
 		}
 
-		this.flush = Executor.getInstance().scheduleWithFixedDelay(new ScheduledExecutable(30, 30, TimeUnit.SECONDS)
+		this.flush = Executor.getInstance().scheduleWithFixedDelay(new Runnable()
 		{
 			@Override
-			public void execute()
+			public void run()
 			{
 				try
 				{
@@ -83,7 +82,7 @@ public final class SystemMetaData extends DatabaseStore implements Service
 					log.error(e.getMessage(), e);
 				}
 			}
-		});
+		}, 30, 30, TimeUnit.SECONDS);
 	}
 
 	@Override

--- a/core/src/main/java/org/radix/hyperscale/executors/Executor.java
+++ b/core/src/main/java/org/radix/hyperscale/executors/Executor.java
@@ -77,38 +77,38 @@ public class Executor
 	public Future<?> schedule(final ScheduledExecutable executable)
 	{
 		Objects.requireNonNull(executable, "Executable to schedule is null");
-		executable.setFuture(this.scheduledExecutor.schedule(executable, executable.getInitialDelay(), executable.getTimeUnit()));
-		return executable.getFuture();
+		return this.scheduledExecutor.schedule(executable, executable.getDelay(), executable.getTimeUnit());
 	}
 
-	public Future<?> scheduleWithFixedDelay(final ScheduledExecutable executable)
-	{
-		Objects.requireNonNull(executable, "Executable to schedule is null");
-		executable.setFuture(this.scheduledExecutor.scheduleWithFixedDelay(executable, executable.getInitialDelay(), executable.getRecurrentDelay(), executable.getTimeUnit()));
-		return executable.getFuture();
-	}
-
-	public Future<?> scheduleAtFixedRate(final ScheduledExecutable executable)
-	{
-		Objects.requireNonNull(executable, "Executable to schedule is null");
-		executable.setFuture(this.scheduledExecutor.scheduleAtFixedRate(executable, executable.getInitialDelay(), executable.getRecurrentDelay(), executable.getTimeUnit()));
-		return executable.getFuture();
-	}
-
-	public Future<?> schedule(final Executable executable, final int initialDelay, final TimeUnit unit)
+	public Future<?> schedule(final Executable executable, final int delay, final TimeUnit unit)
 	{
 		Objects.requireNonNull(executable, "Executable to schedule is null");
 		Objects.requireNonNull(unit, "Executable time unit is null");
-		executable.setFuture(this.scheduledExecutor.schedule(executable, initialDelay, unit));
-		return executable.getFuture();
+		return this.scheduledExecutor.schedule(executable, delay, unit);
 	}
 
-	public Future<?> schedule(final Runnable runnable, final int initialDelay, final TimeUnit unit)
+	public Future<?> schedule(final Runnable runnable, final int delay, final TimeUnit unit)
 	{
 		Objects.requireNonNull(runnable, "Runnable to schedule is null");
 		Objects.requireNonNull(unit, "Executable time unit is null");
 
-		return this.scheduledExecutor.schedule(runnable, initialDelay, unit);
+		return this.scheduledExecutor.schedule(runnable, delay, unit);
+	}
+
+	public Future<?> scheduleWithFixedDelay(final Runnable runnable, final int delay, final int interval, final TimeUnit unit)
+	{
+		Objects.requireNonNull(runnable, "Runnable to schedule is null");
+		Objects.requireNonNull(unit, "Executable time unit is null");
+
+		return this.scheduledExecutor.scheduleWithFixedDelay(runnable, delay, interval, unit);
+	}
+
+	public Future<?> scheduleAtFixedRate(final Runnable runnable, final int delay, final int interval, final TimeUnit unit)
+	{
+		Objects.requireNonNull(runnable, "Runnable to schedule is null");
+		Objects.requireNonNull(unit, "Executable time unit is null");
+
+		return this.scheduledExecutor.scheduleAtFixedRate(runnable, delay, interval, unit);
 	}
 
 	public Future<?> submit(final Runnable runnable)
@@ -126,8 +126,6 @@ public class Executor
 	public Future<?> submit(final Executable executable)
 	{
 		Objects.requireNonNull(executable, "Executable to submit is null");
-		Future<?> future = this.immediateExecutor.submit(executable);
-		executable.setFuture(future);
-		return future;
+		return this.immediateExecutor.submit(executable);
 	}
 }

--- a/core/src/main/java/org/radix/hyperscale/executors/LatchedProcessor.java
+++ b/core/src/main/java/org/radix/hyperscale/executors/LatchedProcessor.java
@@ -70,7 +70,7 @@ public abstract class LatchedProcessor extends Executable
 		
 		try 
 		{
-			while(isTerminated() == false)
+			while(isTerminate() == false)
 			{
 				if (this.signalled == false)
 				{

--- a/core/src/main/java/org/radix/hyperscale/executors/PollingProcessor.java
+++ b/core/src/main/java/org/radix/hyperscale/executors/PollingProcessor.java
@@ -12,7 +12,7 @@ public abstract class PollingProcessor extends Executable
 	{
 		try 
 		{
-			while(isTerminated() == false)
+			while(isTerminate() == false)
 			{
                 process();
 			}

--- a/core/src/main/java/org/radix/hyperscale/executors/ScheduledExecutable.java
+++ b/core/src/main/java/org/radix/hyperscale/executors/ScheduledExecutable.java
@@ -7,37 +7,24 @@ import org.radix.hyperscale.utils.Numbers;
 
 public abstract class ScheduledExecutable extends Executable
 {
-	private final long initialDelay;
-	private final long recurrentDelay;
+	private final long delay;
+//	private final long recurrentDelay;
 	private final TimeUnit unit;
 
-	protected ScheduledExecutable(final long recurrentDelay, final TimeUnit unit)
-	{
-		this(0, recurrentDelay, unit);
-	}
-	
-	protected ScheduledExecutable(final long initialDelay, final long recurrentDelay, final TimeUnit unit)
+	protected ScheduledExecutable(final long delay, final TimeUnit unit)
 	{
 		super();
 		
-		Numbers.isNegative(initialDelay, "Initial delay is negative");
-		Numbers.isNegative(recurrentDelay, "Recurrent delay is negative");
+		Numbers.isNegative(delay, "Delay is negative");
 		this.unit = Objects.requireNonNull(unit, "Time unit for scheduled executable is null");
-
-		this.initialDelay = initialDelay;
-		this.recurrentDelay = recurrentDelay;
+		this.delay = delay;
 	}
 
-	public long getInitialDelay() 
+	public long getDelay() 
 	{ 
-		return this.initialDelay; 
+		return this.delay; 
 	}
 
-	public long getRecurrentDelay() 
-	{ 
-		return this.recurrentDelay; 
-	}
-	
 	public TimeUnit getTimeUnit() 
 	{ 
 		return this.unit; 

--- a/core/src/main/java/org/radix/hyperscale/ledger/AtomHandler.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/AtomHandler.java
@@ -355,7 +355,7 @@ public class AtomHandler implements Service, LedgerInterface
 	@Override
 	public void stop() throws TerminationException 
 	{
-		this.atomProcessor.terminate(true);
+		this.atomProcessor.terminate();
 
 		this.context.getEvents().unregister(this.syncBlockListener);
 		this.context.getEvents().unregister(this.asyncAtomListener);

--- a/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearch.java
+++ b/core/src/main/java/org/radix/hyperscale/ledger/LedgerSearch.java
@@ -68,7 +68,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 		
 		public PrimitiveSearchTask(PrimitiveSearchQuery query, long delay, TimeUnit unit)
 		{
-			super(delay, 0, unit);
+			super(delay, unit);
 			
 			this.query = Objects.requireNonNull(query, "Primitive search query is null");
 			this.responses = Collections.synchronizedMap(new HashMap<ShardGroupID, PrimitiveSearchResponse>());
@@ -125,7 +125,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 		
 		public SubstateSearchTask(SubstateSearchQuery query, long delay, TimeUnit unit)
 		{
-			super(delay, 0, unit);
+			super(delay, unit);
 			
 			this.query = Objects.requireNonNull(query, "Substate search query is null");
 			this.queryFuture = new CompletableFuture<SubstateSearchResponse>();
@@ -167,7 +167,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 
 		public AssociationSearchTask(AssociationSearchQuery query, long delay, TimeUnit unit)
 		{
-			super(delay, 0, unit);
+			super(delay, unit);
 			
 			this.query = Objects.requireNonNull(query, "Association search query is null");
 			this.responses = Collections.synchronizedMap(new HashMap<ShardGroupID, AssociationSearchResponse>());
@@ -652,7 +652,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 							if (searchShardGroupID == localShardGroupID.intValue())
 								continue;
 							
-							StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.CONNECTED).setShardGroupID(ShardGroupID.from(searchShardGroupID)).setSynced(true);
+							StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.SELECT_CONNECTED).setShardGroupID(ShardGroupID.from(searchShardGroupID)).setSynced(true);
 							Collection<AbstractConnection> connectedPeers = this.context.getNetwork().get(standardPeerFilter);
 							if (connectedPeers.isEmpty())
 							{
@@ -712,7 +712,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 			}
 			else	
 			{
-				StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.CONNECTED).setShardGroupID(searchShardGroupID).setSynced(true);
+				StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.SELECT_CONNECTED).setShardGroupID(searchShardGroupID).setSynced(true);
 				Collection<AbstractConnection> connectedStatePeers = this.context.getNetwork().get(standardPeerFilter);
 				if (connectedStatePeers.isEmpty())
 					throw new IOException(this.context.getName()+": No peers available to query substate "+query.getAddress()+" @ shard group ID "+searchShardGroupID);
@@ -777,7 +777,7 @@ final class LedgerSearch implements Service, LedgerSearchInterface
 						if (searchShardGroupID == localShardGroupID.intValue())
 							continue;
 						
-						StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.CONNECTED).setShardGroupID(ShardGroupID.from(searchShardGroupID)).setSynced(true);
+						StandardConnectionFilter standardPeerFilter = StandardConnectionFilter.build(this.context).setStates(ConnectionState.SELECT_CONNECTED).setShardGroupID(ShardGroupID.from(searchShardGroupID)).setSynced(true);
 						Collection<AbstractConnection> connectedPeers = this.context.getNetwork().get(standardPeerFilter);
 						if (connectedPeers.isEmpty())
 						{

--- a/core/src/main/java/org/radix/hyperscale/network/ConnectionTask.java
+++ b/core/src/main/java/org/radix/hyperscale/network/ConnectionTask.java
@@ -11,7 +11,7 @@ public abstract class ConnectionTask extends ScheduledExecutable
 
 	protected ConnectionTask(final AbstractConnection connection, final long delay, final TimeUnit unit)
 	{
-		super(delay, 0, unit);
+		super(delay, unit);
 
 		this.connection = Objects.requireNonNull(connection, "Connection is null");
 	}

--- a/core/src/main/java/org/radix/hyperscale/network/NetworkTask.java
+++ b/core/src/main/java/org/radix/hyperscale/network/NetworkTask.java
@@ -8,6 +8,6 @@ public abstract class NetworkTask extends ScheduledExecutable
 {
 	protected NetworkTask(final long delay, final TimeUnit unit)
 	{
-		super(delay, 0, unit);
+		super(delay, unit);
 	}
 }

--- a/core/src/main/java/org/radix/hyperscale/network/discovery/BootstrapService.java
+++ b/core/src/main/java/org/radix/hyperscale/network/discovery/BootstrapService.java
@@ -103,7 +103,7 @@ public class BootstrapService extends Executable
 
 		final int connectionTimeout = this.context.getConfiguration().get("network.discovery.connection.timeout", 10000);
 		final int readTimeout = this.context.getConfiguration().get("network.discovery.read.timeout", 10000);
-		while(isCompleted == false && isTerminated() == false)
+		while(isCompleted == false && isTerminate() == false)
 		{
 			if (this.context.getNetwork().count(Protocol.TCP, ConnectionState.SELECT_CONNECTED) > 0)
 			{
@@ -213,6 +213,6 @@ public class BootstrapService extends Executable
 		}		
 		
 		networkLog.info(this.context.getName()+": Boostrapper terminating");
-		terminate(false);
+		terminate();
 	}
 }

--- a/core/src/main/java/org/radix/hyperscale/tools/spam/Spamathon.java
+++ b/core/src/main/java/org/radix/hyperscale/tools/spam/Spamathon.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -161,10 +160,8 @@ final public class Spamathon
 	        }
 	    }	    
 
-	    final Future<?> spamFuture = this.spamExecutor.submit(spammer);		
-	    spammer.setFuture(spamFuture);
+	    this.spamExecutor.submit(spammer);		
 		this.spammer = spammer;
-
 		return (T) spammer;
 	}
 


### PR DESCRIPTION
Refactor of custom executables due to Java's insane handling of futures
Issues of "phantom futures" which didn't cancel correctly, leaving
hanging state in various modules which were using the custom executable
interfaces.

Problem identified to be the manner which Javas executor framework
handles scheduling and management.